### PR TITLE
upgrade tests to run in main branch

### DIFF
--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -194,7 +194,7 @@ jobs:
           - name: PRO/Standalone - GCP/us-central1 - Upgrade Version
             if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
             testFile: test_upgrade_version.py
-            tierName: pro-${{ github.ref_name }}
+            tierName: pro-main
             cloudProvider: gcp
             cloudRegion: us-central1
             subscriptionId: sub-GJPV3NoNC0
@@ -204,7 +204,7 @@ jobs:
           - name: PRO/SingleZone - GCP/us-central1 - Upgrade Version
             if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
             testFile: test_upgrade_version.py
-            tierName: pro-${{ github.ref_name }}
+            tierName: pro-main
             cloudProvider: gcp
             cloudRegion: us-central1
             subscriptionId: sub-GJPV3NoNC0


### PR DESCRIPTION
fix #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the tier name for deployment jobs to a static value of `pro-main`, ensuring consistency in the GCP environment regardless of the branch or tag used during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->