### PR TITLE
fix delete custom networks

### DIFF
--- a/.github/actions/create-omnistrate-custom-network/action.yaml
+++ b/.github/actions/create-omnistrate-custom-network/action.yaml
@@ -27,4 +27,4 @@ runs:
   entrypoint: /bin/sh
   args:
     - -c
-    - "/usr/local/bin/omnistrate-ctl login --email ${{ inputs.username }} --password ${{ inputs.password }} && /usr/local/bin/omnistrate-ctl custom-network create --cloud-provider ${{ inputs.cloud_provider }} --region ${{ inputs.region }} --cidr ${{ inputs.cidr }} --name '${{ inputs.name }}' || true"
+    - "/usr/local/bin/omnistrate-ctl login --email ${{ inputs.username }} --password ${{ inputs.password }} && /usr/local/bin/omnistrate-ctl custom-network list -o json | jq -r '.[].custom_network_name' | grep -q '${{ inputs.name }}' || /usr/local/bin/omnistrate-ctl custom-network create --cloud-provider ${{ inputs.cloud_provider }} --region ${{ inputs.region }} --cidr ${{ inputs.cidr }} --name '${{ inputs.name }}'"

--- a/.github/actions/create-omnistrate-custom-network/action.yaml
+++ b/.github/actions/create-omnistrate-custom-network/action.yaml
@@ -27,4 +27,4 @@ runs:
   entrypoint: /bin/sh
   args:
     - -c
-    - "/usr/local/bin/omnistrate-ctl login --email ${{ inputs.username }} --password ${{ inputs.password }} && /usr/local/bin/omnistrate-ctl custom-network list -o json | jq -r '.[].custom_network_name' | grep -q '${{ inputs.name }}' || /usr/local/bin/omnistrate-ctl custom-network create --cloud-provider ${{ inputs.cloud_provider }} --region ${{ inputs.region }} --cidr ${{ inputs.cidr }} --name '${{ inputs.name }}'"
+    - "/usr/local/bin/omnistrate-ctl login --email ${{ inputs.username }} --password ${{ inputs.password }} && /usr/local/bin/omnistrate-ctl custom-network list -o json | grep -q '${{ inputs.name }}' || /usr/local/bin/omnistrate-ctl custom-network create --cloud-provider ${{ inputs.cloud_provider }} --region ${{ inputs.region }} --cidr ${{ inputs.cidr }} --name '${{ inputs.name }}'"

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -603,3 +603,29 @@ jobs:
         run: |
           poetry run python -u ./omnistrate_tests/${{ matrix.instances.testFile }} ${{ secrets.OMNISTRATE_USERNAME }} ${{ secrets.OMNISTRATE_PASSWORD }} ${{ env.CLOUD_PROVIDER }} ${{ env.CLOUD_REGION }} --service-id ${{ env.SERVICE_ID }} --environment-id ${{ env.ENVIRONMENT_ID }} ${{ env.extraParams }}
 
+  # Runs only if the branch is 'main' or 'v*'
+  delete-networks:
+    runs-on: ubuntu-latest
+    needs: test
+    if: contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Delete Omnistrate Custom Network - GCP
+        uses: ./.github/actions/delete-omnistrate-custom-network
+        continue-on-error: true
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          custom_network_name: ${{ env.GCP_NETWORK_NAME }}
+
+      - name: Delete Omnistrate Custom Network - AWS
+        continue-on-error: true
+        uses: ./.github/actions/delete-omnistrate-custom-network
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          custom_network_name: ${{ env.AWS_NETWORK_NAME }}
+
+      

--- a/.github/workflows/delete-omnistrate-service-plan.yaml
+++ b/.github/workflows/delete-omnistrate-service-plan.yaml
@@ -2,12 +2,17 @@ name: Cleanup after PR
 
 on:
   workflow_dispatch:
+      inputs:
+        ref-name: 
+          description: 'The name of the branch or tag to delete'
+          required: true
+          default: 'main'
   pull_request:
     types: [closed]
 
 env: 
-  GCP_NETWORK_NAME: gcp-network-${{ github.ref_name }}
-  AWS_NETWORK_NAME: aws-network-${{ github.ref_name }}
+  GCP_NETWORK_NAME: gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || inputs.ref-name }}
+  AWS_NETWORK_NAME: aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || inputs.ref-name }}
 
 jobs:
   delete-networks:


### PR DESCRIPTION
fix #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job `delete-networks` for cleaning up custom networks after testing.
	- Added an input parameter `ref-name` for branch or tag deletion in the service plan workflow.

- **Improvements**
	- Enhanced flexibility for specifying branch or tag for deletion in the service plan workflow.
	- Updated environment variables to adapt based on event context, ensuring accurate network and service plan names.
	- Improved custom network creation process to prevent unnecessary attempts if the network already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->