### PR TITLE
154 fix sentinel healthcheck for replicas not running sentinel

### DIFF
--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -526,7 +526,7 @@ if [[ $RUN_METRICS -eq 1 ]]; then
   redis_exporter_pid=$!
 fi
 
-if [[ $DEBUG -eq 1 && $RUN_SENTINEL -eq 1 ]]; then
+if [[ $DEBUG -eq 1 && $RUN_SENTINEL -eq 1 ]] && [[ ("$HOSTNAME" =~ ^sentinel.*0 ) || ("$NODE_INDEX" == "1" || "$NODE_INDEX" == "0") ]]; then
   # Check for crossed namespace
   echo "Checking for crossed namespace"
   while true; do

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -518,7 +518,7 @@ if [ -f /usr/local/bin/healthcheck ]; then
     healthcheck_pid=$!
   fi
 
-  if [[ $RUN_SENTINEL -eq 1 ]] && [[ $RUN_HEALTH_CHECK_SENTINEL -eq 1 ]] && [[ ("$HOSTNAME" =~ ^sentinel.*0 ) || ("$NODE_INDEX" == "1" || "$NODE_INDEX" == "0") ]]; then
+  if [[ $RUN_SENTINEL -eq 1 ]] && [[ $RUN_HEALTH_CHECK_SENTINEL -eq 1 ]] && [[ "$NODE_INDEX" == "1" || "$NODE_INDEX" == "0" ]]; then
     echo "Starting Sentinel Healthcheck"
     healthcheck sentinel &
     sentinel_healthcheck_pid=$!
@@ -534,7 +534,7 @@ if [[ $RUN_METRICS -eq 1 ]]; then
   redis_exporter_pid=$!
 fi
 
-if [[ $DEBUG -eq 1 && $RUN_SENTINEL -eq 1 ]] && [[ ("$HOSTNAME" =~ ^sentinel.*0 ) || ("$NODE_INDEX" == "1" || "$NODE_INDEX" == "0") ]]; then
+if [[ $DEBUG -eq 1 && $RUN_SENTINEL -eq 1 ]] && [[ "$NODE_INDEX" == "1" || "$NODE_INDEX" == "0" ]]; then
   # Check for crossed namespace
   echo "Checking for crossed namespace"
   while true; do

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -510,7 +510,7 @@ if [ -f /usr/local/bin/healthcheck ]; then
     healthcheck_pid=$!
   fi
 
-  if [[ $RUN_SENTINEL -eq 1 ]] && [[ $RUN_HEALTH_CHECK_SENTINEL -eq 1 ]]; then
+  if [[ $RUN_SENTINEL -eq 1 ]] && [[ $RUN_HEALTH_CHECK_SENTINEL -eq 1 ]] && [[ ("$HOSTNAME" =~ ^sentinel.*0 ) || ("$NODE_INDEX" == "1" || "$NODE_INDEX" == "0") ]]; then
     echo "Starting Sentinel Healthcheck"
     healthcheck sentinel &
     sentinel_healthcheck_pid=$!


### PR DESCRIPTION
fix #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved conditions for initiating health checks, ensuring they only start for specific node indices (0 or 1).
	- Updated debug logging conditions to enhance relevance based on node configuration.

- **Chores**
	- Refined script logic for better control flow without altering core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->