### PR TITLE
updated instance type for rebalance and sentinel services

### DIFF
--- a/omnistrate.enterprise.yaml
+++ b/omnistrate.enterprise.yaml
@@ -1127,6 +1127,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
@@ -1624,6 +1626,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
@@ -1946,6 +1950,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     <<: *rebalanceparam
     environment:
       - IS_MULTI_ZONE=0
@@ -2251,6 +2257,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     <<: *rebalanceparam
     environment:
       - IS_MULTI_ZONE=1

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -1138,6 +1138,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
@@ -1683,6 +1685,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
@@ -2031,6 +2035,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     <<: *rebalanceparam
     environment:
       - NODE_HOST=$sys.network.node.externalEndpoint
@@ -2342,6 +2348,8 @@ services:
       instanceTypes:
         - cloudProvider: gcp
           name: e2-small
+        - cloudProvider: aws
+          name: t3a.small
     <<: *rebalanceparam
     environment:
       - IS_MULTI_ZONE=1


### PR DESCRIPTION
fix #185 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new AWS instance type `t3a.small` for enhanced flexibility in deployment across multiple components, including `sentinel-sz`, `sentinel-mz`, `cluster-sz-rebalance`, and `Cluster-Multi-Zone`.
  
- **Bug Fixes**
	- Maintained existing configurations for TLS, user credentials, and persistence to ensure core functionality and security settings remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->