### PR TITLE
removed metrics and disabled AOF for free instance

### DIFF
--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -154,7 +154,7 @@ handle_sigterm() {
     role=$(redis-cli -p $NODE_PORT -a $ADMIN_PASSWORD --no-auth-warning $TLS_CONNECTION_STRING info replication | grep role)
     if [[ "$role" =~ ^role:master ]];then IS_REPLICA=0 ;fi
     remove_master_from_group
-    redis-cli -p $SENTINEL_PORT -a $ADMIN_PASSWORD --no-auth-warning $TLS_CONNECTION_STRING SHUTDOWN
+    redis-cli -a $ADMIN_PASSWORD --no-auth-warning $TLS_CONNECTION_STRING SHUTDOWN
   fi
 
   if [[ $RUN_SENTINEL -eq 1 && ! -z $sentinel_pid ]]; then

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -152,9 +152,9 @@ handle_sigterm() {
   if [[ $RUN_NODE -eq 1 && ! -z $falkordb_pid ]]; then
     #DO NOT USE is_replica FUNCTION
     role=$(redis-cli -p $NODE_PORT -a $ADMIN_PASSWORD --no-auth-warning $TLS_CONNECTION_STRING info replication | grep role)
-    
     if [[ "$role" =~ ^role:master ]];then IS_REPLICA=0 ;fi
     remove_master_from_group
+    redis-cli -p $SENTINEL_PORT -a $ADMIN_PASSWORD --no-auth-warning $TLS_CONNECTION_STRING SHUTDOWN
   fi
 
   if [[ $RUN_SENTINEL -eq 1 && ! -z $sentinel_pid ]]; then

--- a/omnistrate.free.yaml
+++ b/omnistrate.free.yaml
@@ -135,7 +135,7 @@ services:
     environment:
       - RUN_NODE=1
       - RUN_SENTINEL=0
-      - RUN_METRICS=1
+      - RUN_METRICS=0
       - RUN_HEALTH_CHECK=1
       - BROWSER=0
       - NODE_HOST=$sys.network.node.externalEndpoint
@@ -154,6 +154,7 @@ services:
       - FALKORDB_TIMEOUT_DEFAULT=0
       - FALKORDB_RESULT_SET_SIZE=10000
       - FALKORDB_QUERY_MEM_CAPACITY=52428800
+      - PERSISTENCE_AOF_CONFIG=no
     ports:
       - "6379:6379"
       # - "9121:9121"

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -122,7 +122,7 @@ x-falkordbMetrics: &metrics
         aggregationFunction: sum
 
 x-omnistrate-integrations:
-  - omnistrateLogging:
+  - omnistrateLogging
   - omnistrateMetrics:
       additionalMetrics:
         node-s:


### PR DESCRIPTION
fix #211 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable `PERSISTENCE_AOF_CONFIG` in the configuration.
	- Added a `delete-networks` job to the GitHub Actions workflow for cleanup after testing.

- **Bug Fixes**
	- Updated the `RUN_METRICS` environment variable to disable metrics collection for the Free service.
	- Enhanced the shutdown process for Redis service during termination.

- **Chores**
	- Refined the metrics handling process in the GitHub Actions workflow by targeting specific keys for deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->