### PR TITLE
increase default upgrade timeout

### DIFF
--- a/falkordb-cluster/cluster-entrypoint.sh
+++ b/falkordb-cluster/cluster-entrypoint.sh
@@ -78,7 +78,7 @@ fi
 
 meet_unknown_nodes(){
   # Had to add sleep until things are stable (nodes that can communicate should be given time to do so)
-  sleep 120
+  sleep 30
   # This fixes an issue where two nodes restart (ex: cluster-sz-1 (x.x.x.1) and cluster-sz-2 (x.x.x.2)) and their ips are switched
   # cluster-sz-1 gets (x.x.x.2) and cluster-sz-2 gets (x.x.x.1).
   # This can be caught by looking for the lines in the /data/nodes.conf file which have either the "fail" state or the "0:@0".

--- a/omnistrate_tests/classes/omnistrate_fleet_instance.py
+++ b/omnistrate_tests/classes/omnistrate_fleet_instance.py
@@ -389,7 +389,7 @@ class OmnistrateFleetInstance:
         source_version: str,
         target_version: str,
         wait_until_ready: bool = False,
-        upgrade_timeout: int = 1200,
+        upgrade_timeout: int = 2400,
     ):
 
         data = {


### PR DESCRIPTION
set meet_unknown_nodes sleep to 30

fix #215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Reduced node meeting wait time in cluster entrypoint script from 120 to 30 seconds.

- **Testing**
	- Extended upgrade timeout in fleet instance test class from 1200 to 2400 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->