### PR TITLE
added missing healthcheck to the free tier

### DIFF
--- a/omnistrate.free.yaml
+++ b/omnistrate.free.yaml
@@ -169,6 +169,26 @@ services:
         reservations:
           cpus: "0.1"
           memory: 200M
+    x-omnistrate-actionhooks:
+      - scope: NODE
+        type: HEALTH_CHECK
+        commandTemplate: >
+          #!/bin/bash
+
+          HEALTH_CHECK_URL="${HEALTH_CHECK_HOST:-localhost}:${HEALTH_CHECK_PORT:-8081}/healthcheck"
+
+          call_health_check() {
+
+            echo "Health check URL: $HEALTH_CHECK_URL"
+            curl -sf $HEALTH_CHECK_URL
+            
+            if [ $? -ne 0 ]; then
+              echo "Health check failed"
+              exit 1
+            fi
+          }
+
+          call_health_check
 
 secrets:
   adminpasspath:

--- a/omnistrate_tests/test_update_memory.py
+++ b/omnistrate_tests/test_update_memory.py
@@ -54,6 +54,16 @@ parser.add_argument("--cluster-replicas", required=False, default="1")
 parser.add_argument("--host-count", required=False, default="6")
 parser.add_argument("--persist-instance-on-fail",action="store_true")
 
+parser.add_argument(
+    "--deployment-create-timeout-seconds", required=False, default=2600, type=int
+)
+parser.add_argument(
+    "--deployment-delete-timeout-seconds", required=False, default=2600, type=int
+)
+parser.add_argument(
+    "--deployment-failover-timeout-seconds", required=False, default=2600, type=int
+)
+
 parser.set_defaults(tls=False)
 args = parser.parse_args()
 
@@ -102,9 +112,9 @@ def test_update_memory():
         product_tier_key=product_tier.product_tier_key,
         resource_key=args.resource_key,
         subscription_id=args.subscription_id,
-        deployment_create_timeout_seconds=2400,
-        deployment_delete_timeout_seconds=2400,
-        deployment_failover_timeout_seconds=2400
+        deployment_create_timeout_seconds=args.deployment_create_timeout_seconds,
+        deployment_delete_timeout_seconds=args.deployment_delete_timeout_seconds,
+        deployment_failover_timeout_seconds=args.deployment_failover_timeout_seconds
     )
 
     try:


### PR DESCRIPTION
fix #214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a health check mechanism for the `node-f` service to monitor its operational status.
	- Implemented a configurable health check that can verify service availability using customizable host and port settings.
	- Introduced new command-line arguments for flexible configuration of deployment timeouts in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->