### PR TITLE
added tests for private instances

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -1,0 +1,35 @@
+name: Cleanup running runner
+description: Cleans a spot instance that has the specified label
+
+inputs:
+  service_account_key:
+    description: GCP Service account key
+    required: true
+  project_id:
+    description: GCP Project ID
+    required: true
+  zone:
+    description: GCP Zone
+    required: true
+  instance_label:
+    description: Label to identify the instance
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: auth
+      shell: bash
+      run: echo '${{ inputs.service_account_key }}' | gcloud --project  '${{ inputs.project_id }}' --quiet auth activate-service-account --key-file - >/dev/null 2>&1
+    - id: get-runner-id
+      shell: bash
+      run: |
+        runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)
+        if [ -z "$runner_id" ]; then
+          echo "Instance with label ${{ inputs.instance_label }} not found"
+          exit 1
+        fi
+        echo "runner_id=$runner_id" >> $GITHUB_OUTPUT
+    - id: kill-runner
+      shell: bash
+      run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ inputs.zone }} --quiet

--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -30,4 +30,4 @@ runs:
           exit 0
         fi
         echo "runner_id=$runner_id" >> $GITHUB_OUTPUT
-        gcloud compute instances delete $runner_id" --zone=${{ inputs.zone }} --quiet
+        gcloud compute instances delete $runner_id --zone=${{ inputs.zone }} --quiet

--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -21,7 +21,7 @@ runs:
     - id: auth
       shell: bash
       run: echo '${{ inputs.service_account_key }}' | gcloud --project  '${{ inputs.project_id }}' --quiet auth activate-service-account --key-file - >/dev/null 2>&1
-    - id: get-runner-id
+    - id: get-runner-id and kill-runner
       shell: bash
       run: |
         runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)
@@ -30,6 +30,4 @@ runs:
           exit 0
         fi
         echo "runner_id=$runner_id" >> $GITHUB_OUTPUT
-    - id: kill-runner
-      shell: bash
-      run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ inputs.zone }} --quiet
+        gcloud compute instances delete $runner_id" --zone=${{ inputs.zone }} --quiet

--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -27,7 +27,7 @@ runs:
         runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)
         if [ -z "$runner_id" ]; then
           echo "Instance with label ${{ inputs.instance_label }} not found"
-          exit 1
+          exit 0
         fi
         echo "runner_id=$runner_id" >> $GITHUB_OUTPUT
     - id: kill-runner

--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -21,7 +21,7 @@ runs:
     - id: auth
       shell: bash
       run: echo '${{ inputs.service_account_key }}' | gcloud --project  '${{ inputs.project_id }}' --quiet auth activate-service-account --key-file - >/dev/null 2>&1
-    - id: get-runner-id and kill-runner
+    - id: get-runner-id-and-kill-runner
       shell: bash
       run: |
         runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -465,26 +465,6 @@ jobs:
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
             extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
           ###################### GCP PRIVATE ######################
-          - name: Free - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_standalone.py
-            tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'free' --replica-id 'node-f-0' --network-type PRIVATE --instance-name 'test-free-failover-private' --instance-description 'test-free-failover-private' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_standalone.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --network-type PRIVATE --instance-name 'test-standalone-failover-private' --instance-description 'test-standalone-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
           - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
             if: "true"
             testFile: test_replication.py
@@ -505,16 +485,6 @@ jobs:
             serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
             extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type PRIVATE --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_standalone.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --network-type PRIVATE --instance-name 'test-standalone-failover-tls-private' --instance-description 'test-standalone-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
           - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
             if: "true"
             testFile: test_replication.py
@@ -535,66 +505,7 @@ jobs:
             serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
             extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls-private' --network-type PRIVATE --instance-description 'test-mz-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Update Memory
-            if: "true"
-            testFile: test_update_memory.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-update-memory-private' --network-type PRIVATE  --instance-description 'test-standalone-update-memory-private' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Update Memory
-            if: "true"
-            testFile: test_update_memory.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-update-memory-private'  --network-type PRIVATE --instance-description 'test-replication-update-memory-private' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Update Memory
-            if: "true"
-            testFile: test_update_memory.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-update-memory-private'  --network-type PRIVATE --instance-description 'test-cluster-update-memory-private' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
-          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Upgrade Version
-            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-            testFile: test_upgrade_version.py
-            tierName: pro-main
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-upgrade-private' --network-type PRIVATE --instance-description 'test-standalone-upgrade-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Upgrade Version
-            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-            testFile: test_upgrade_version.py
-            tierName: pro-main
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-upgrade-private' --network-type PRIVATE --instance-description 'test-replication-upgrade-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Upgrade Version
-            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-            testFile: test_upgrade_version.py
-            tierName: pro-main
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-upgrade-private' --network-type PRIVATE --instance-description 'test-cluster-upgrade-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+
           - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
             if: "true"
             testFile: test_cluster.py
@@ -637,16 +548,7 @@ jobs:
             extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-failover-tls-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
 
           # Enterprise
-          - name: Enterprise/Standalone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_standalone.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --network-type PRIVATE --instance-name 'test-standalone-enterprise-failover-private' --instance-description 'test-standalone-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+
           - name: Enterprise/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
             if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
             testFile: test_replication.py
@@ -688,26 +590,6 @@ jobs:
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
             extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-enterprise-failover-private' --instance-description 'test-cluster-mz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
 
-          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Test add/remove replica
-            if: "true"
-            testFile: test_replication_replicas.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica-private' --network-type PRIVATE --instance-description 'test-replication-add-remove-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Test add/remove replica
-            if: "true"
-            testFile: test_replication_replicas.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --network-type PRIVATE --instance-name 'test-mz-add-remove-replica-private' --instance-description 'test-replication-add-remove-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
             ###################### AWS ######################
           - name: Free - AWS/us-east-2 - Failover & Persistence
             if: "true"

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -56,661 +56,661 @@ jobs:
           arm: ${{ matrix.machines.arm }}
           image: ${{ matrix.machines.image }}
 
-  build-and-push:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - dockerfile: ./falkordb-node/Dockerfile
-            image-name: falkordb-node
-          - dockerfile: ./falkordb-cluster/Dockerfile
-            image-name: falkordb-cluster
-          - dockerfile: ./falkordb-cluster-rebalance/Dockerfile
-            image-name: falkordb-cluster-rebalance
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  # build-and-push:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       include:
+  #         - dockerfile: ./falkordb-node/Dockerfile
+  #           image-name: falkordb-node
+  #         - dockerfile: ./falkordb-cluster/Dockerfile
+  #           image-name: falkordb-cluster
+  #         - dockerfile: ./falkordb-cluster-rebalance/Dockerfile
+  #           image-name: falkordb-cluster-rebalance
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          build-args: FALKORDB_VERSION=${{ env.FALKORDB_VERSION }}
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: falkordb/${{ matrix.image-name }}:dev-${{ github.event.head_commit.id || github.run_id }}
+  #     - name: Build and push
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         build-args: FALKORDB_VERSION=${{ env.FALKORDB_VERSION }}
+  #         context: .
+  #         file: ${{ matrix.dockerfile }}
+  #         push: true
+  #         tags: falkordb/${{ matrix.image-name }}:dev-${{ github.event.head_commit.id || github.run_id }}
 
-  omnistrate-update-plans:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        plans:
-          - service-name: FalkorDB
-            plan-name: FalkorDB Free
-            file: omnistrate.free.yaml
-            key: free
-            tier-name: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          - service-name: FalkorDB
-            plan-name: FalkorDB Pro
-            file: omnistrate.pro.yaml
-            key: pro
-            tier-name: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
-          - service-name: FalkorDB
-            plan-name: FalkorDB Enterprise
-            file: omnistrate.enterprise.yaml
-            key: enterprise
-            tier-name: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  # omnistrate-update-plans:
+  #   needs: build-and-push
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 1
+  #     matrix:
+  #       plans:
+  #         - service-name: FalkorDB
+  #           plan-name: FalkorDB Free
+  #           file: omnistrate.free.yaml
+  #           key: free
+  #           tier-name: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #         - service-name: FalkorDB
+  #           plan-name: FalkorDB Pro
+  #           file: omnistrate.pro.yaml
+  #           key: pro
+  #           tier-name: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
+  #         - service-name: FalkorDB
+  #           plan-name: FalkorDB Enterprise
+  #           file: omnistrate.enterprise.yaml
+  #           key: enterprise
+  #           tier-name: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Replace Variables
-        run: |
-          sed -i 's/$GcpProjectId/${{ vars.GCP_PROJECT_ID }}/g' ${{ matrix.plans.file }}
-          sed -i 's/$GcpProjectNumber/${{ vars.GCP_PROJECT_NUMBER }}/g' ${{ matrix.plans.file }}
-          sed -i 's/$GcpServiceAccountEmail/${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}/g' ${{ matrix.plans.file }}
-          sed -i 's/$AwsAccountId/${{ vars.AWS_ACCOUNT_ID }}/g' ${{ matrix.plans.file }}
-          sed -i 's|$AwsBootstrapRoleAccountArn|${{ vars.AWS_BOOTSTRAP_ROLE_ACCOUNT_ARN }}|g' ${{ matrix.plans.file }}
-          sed -i 's/$FalkorDBNodeImage/falkordb\/${{ env.NODE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
-          sed -i 's/$FalkorDBClusterImage/falkordb\/${{ env.CLUSTER_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
-          sed -i 's/$FalkorDBClusterRebalanceImage/falkordb\/${{ env.CLUSTER_REBALANCE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
-          sed -i 's/${{ matrix.plans.plan-name }}/${{ matrix.plans.tier-name }}/g' ${{ matrix.plans.file }}
+  #     - name: Replace Variables
+  #       run: |
+  #         sed -i 's/$GcpProjectId/${{ vars.GCP_PROJECT_ID }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's/$GcpProjectNumber/${{ vars.GCP_PROJECT_NUMBER }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's/$GcpServiceAccountEmail/${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's/$AwsAccountId/${{ vars.AWS_ACCOUNT_ID }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's|$AwsBootstrapRoleAccountArn|${{ vars.AWS_BOOTSTRAP_ROLE_ACCOUNT_ARN }}|g' ${{ matrix.plans.file }}
+  #         sed -i 's/$FalkorDBNodeImage/falkordb\/${{ env.NODE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's/$FalkorDBClusterImage/falkordb\/${{ env.CLUSTER_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's/$FalkorDBClusterRebalanceImage/falkordb\/${{ env.CLUSTER_REBALANCE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
+  #         sed -i 's/${{ matrix.plans.plan-name }}/${{ matrix.plans.tier-name }}/g' ${{ matrix.plans.file }}
 
-      - name: Remove custom metrics for testing
-        run: |
-          yq eval 'del(.x-omnistrate-integrations[1].omnistrateMetrics) | .x-omnistrate-integrations |= map(select(type != "!!map" or length > 0))' ${{ matrix.plans.file }} > ${{ matrix.plans.file }}.tmp
-          mv ${{ matrix.plans.file }}.tmp ${{ matrix.plans.file }}
+  #     - name: Remove custom metrics for testing
+  #       run: |
+  #         yq eval 'del(.x-omnistrate-integrations[1].omnistrateMetrics) | .x-omnistrate-integrations |= map(select(type != "!!map" or length > 0))' ${{ matrix.plans.file }} > ${{ matrix.plans.file }}.tmp
+  #         mv ${{ matrix.plans.file }}.tmp ${{ matrix.plans.file }}
       
-      - name: Upload yaml as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.plans.file }}
-          path: ${{ matrix.plans.file }}
+  #     - name: Upload yaml as artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ matrix.plans.file }}
+  #         path: ${{ matrix.plans.file }}
 
-      - name: Create FALKORDB_PASSWORD/ADMIN_PASSWORD files
-        run: |
-          export sec=$(grep '^secrets' omnistrate.free.yaml)
-          if [[ -n "$sec" ]];then
-            mkdir -p secrets || { echo "Failed to create secrets directory"; exit 1; }
-            echo '{{ $var.falkordbPassword }}' > ./secrets/falkordbpassword || { echo "Failed to write falkordbpassword"; exit 1; }
-            echo '{{ $func.random(string, 16, $sys.deterministicSeedValue) }}' > ./secrets/adminpassword || { echo "Failed to write adminpassword"; exit 1; }
-            echo '{{ $var.adminPassword }}' > ./secrets/grafana_admin_password || { echo "Failed to write grafana_admin_password"; exit 1; }
-            echo '{{ $func.random(string, 16, $sys.deterministicSeedValue)  }}' > ./secrets/grafana_secret_key || { echo "Failed to write grafana_secret_key"; exit 1; }
-            echo '{{ $var.smtpPassword }}' > ./secrets/grafana_smtp_password || { echo "Failed to write grafana_smtp_password"; exit 1; }
-          else
-            echo "secrets option was not used"
-            exit 0
-          fi
+  #     - name: Create FALKORDB_PASSWORD/ADMIN_PASSWORD files
+  #       run: |
+  #         export sec=$(grep '^secrets' omnistrate.free.yaml)
+  #         if [[ -n "$sec" ]];then
+  #           mkdir -p secrets || { echo "Failed to create secrets directory"; exit 1; }
+  #           echo '{{ $var.falkordbPassword }}' > ./secrets/falkordbpassword || { echo "Failed to write falkordbpassword"; exit 1; }
+  #           echo '{{ $func.random(string, 16, $sys.deterministicSeedValue) }}' > ./secrets/adminpassword || { echo "Failed to write adminpassword"; exit 1; }
+  #           echo '{{ $var.adminPassword }}' > ./secrets/grafana_admin_password || { echo "Failed to write grafana_admin_password"; exit 1; }
+  #           echo '{{ $func.random(string, 16, $sys.deterministicSeedValue)  }}' > ./secrets/grafana_secret_key || { echo "Failed to write grafana_secret_key"; exit 1; }
+  #           echo '{{ $var.smtpPassword }}' > ./secrets/grafana_smtp_password || { echo "Failed to write grafana_smtp_password"; exit 1; }
+  #         else
+  #           echo "secrets option was not used"
+  #           exit 0
+  #         fi
 
-      - name: Update Omnistrate plan
-        uses: ./.github/actions/update-omnistrate-plan
-        id: update_omnistrate_plan
-        with:
-          username: ${{ secrets.OMNISTRATE_USERNAME }}
-          password: ${{ secrets.OMNISTRATE_PASSWORD }}
-          file: ${{ matrix.plans.file }}
-          service-name: ${{ matrix.plans.service-name }}
-          environment: testing
-          environment-type: qa
-          release-description: dev-${{ github.event.head_commit.id || github.run_id }}
+  #     - name: Update Omnistrate plan
+  #       uses: ./.github/actions/update-omnistrate-plan
+  #       id: update_omnistrate_plan
+  #       with:
+  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
+  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
+  #         file: ${{ matrix.plans.file }}
+  #         service-name: ${{ matrix.plans.service-name }}
+  #         environment: testing
+  #         environment-type: qa
+  #         release-description: dev-${{ github.event.head_commit.id || github.run_id }}
 
-  create-custom-networks:
-    needs: omnistrate-update-plans
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  # create-custom-networks:
+  #   needs: omnistrate-update-plans
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Create Omnistrate Custom Network - GCP
-        if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
-        uses: ./.github/actions/create-omnistrate-custom-network
-        id: create_custom_network_gcp
-        with:
-          username: ${{ secrets.OMNISTRATE_USERNAME }}
-          password: ${{ secrets.OMNISTRATE_PASSWORD }}
-          cloud_provider: gcp
-          region: us-central1
-          cidr: "73.0.0.0/16"
-          name: ${{ env.GCP_NETWORK_NAME}}
+  #     - name: Create Omnistrate Custom Network - GCP
+  #       if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+  #       uses: ./.github/actions/create-omnistrate-custom-network
+  #       id: create_custom_network_gcp
+  #       with:
+  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
+  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
+  #         cloud_provider: gcp
+  #         region: us-central1
+  #         cidr: "73.0.0.0/16"
+  #         name: ${{ env.GCP_NETWORK_NAME}}
 
-      - name: Create Omnistrate Custom Network - AWS
-        if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
-        uses: ./.github/actions/create-omnistrate-custom-network
-        id: create_custom_network_aws
-        with:
-          username: ${{ secrets.OMNISTRATE_USERNAME }}
-          password: ${{ secrets.OMNISTRATE_PASSWORD }}
-          cloud_provider: aws
-          region: us-east-2
-          cidr: "73.0.0.0/16"
-          name: ${{ env.AWS_NETWORK_NAME }}
+  #     - name: Create Omnistrate Custom Network - AWS
+  #       if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+  #       uses: ./.github/actions/create-omnistrate-custom-network
+  #       id: create_custom_network_aws
+  #       with:
+  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
+  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
+  #         cloud_provider: aws
+  #         region: us-east-2
+  #         cidr: "73.0.0.0/16"
+  #         name: ${{ env.AWS_NETWORK_NAME }}
 
-  test:
-    needs: [create-custom-networks, create-runners]
-    runs-on: ${{ matrix.instances.runner_label || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        instances:
-          ###################### GCP ######################
-          - name: Free - GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_standalone.py
-            tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_standalone.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover'  --instance-description 'test-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_standalone.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover-tls' --instance-description 'test-standalone-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-tls'  --instance-description 'test-sz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls' --instance-description 'test-mz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - GCP/us-central1 - Update Memory
-            if: "true"
-            testFile: test_update_memory.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-update-memory'  --instance-description 'test-standalone-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - GCP/us-central1 - Update Memory
-            if: "true"
-            testFile: test_update_memory.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-update-memory'  --instance-description 'test-replication-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/ClusterSingleZone - GCP/us-central1 - Update Memory
-            if: "true"
-            testFile: test_update_memory.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-update-memory'  --instance-description 'test-cluster-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
-          - name: PRO/Standalone - GCP/us-central1 - Upgrade Version
-            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-            testFile: test_upgrade_version.py
-            tierName: pro-main
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-upgrade' --instance-description 'test-standalone-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - GCP/us-central1 - Upgrade Version
-            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-            testFile: test_upgrade_version.py
-            tierName: pro-main
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-upgrade' --instance-description 'test-replication-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/ClusterSingleZone - GCP/us-central1 - Upgrade Version
-            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-            testFile: test_upgrade_version.py
-            tierName: pro-main
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-upgrade' --instance-description 'test-cluster-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
-          - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-          - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-          - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-failover-tls' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-          - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover-tls' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+  # test:
+  #   needs: [create-custom-networks, create-runners]
+  #   runs-on: ${{ matrix.instances.runner_label || 'ubuntu-latest' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       instances:
+  #         ###################### GCP ######################
+  #         - name: Free - GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_standalone.py
+  #           tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_standalone.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover'  --instance-description 'test-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence With TLS
+  #           if: "true"
+  #           testFile: test_standalone.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover-tls' --instance-description 'test-standalone-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence With TLS
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-tls'  --instance-description 'test-sz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence With TLS
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls' --instance-description 'test-mz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/Standalone - GCP/us-central1 - Update Memory
+  #           if: "true"
+  #           testFile: test_update_memory.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-update-memory'  --instance-description 'test-standalone-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/SingleZone - GCP/us-central1 - Update Memory
+  #           if: "true"
+  #           testFile: test_update_memory.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-update-memory'  --instance-description 'test-replication-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Update Memory
+  #           if: "true"
+  #           testFile: test_update_memory.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-update-memory'  --instance-description 'test-cluster-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+  #         - name: PRO/Standalone - GCP/us-central1 - Upgrade Version
+  #           if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+  #           testFile: test_upgrade_version.py
+  #           tierName: pro-main
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-upgrade' --instance-description 'test-standalone-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/SingleZone - GCP/us-central1 - Upgrade Version
+  #           if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+  #           testFile: test_upgrade_version.py
+  #           tierName: pro-main
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-upgrade' --instance-description 'test-replication-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Upgrade Version
+  #           if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+  #           testFile: test_upgrade_version.py
+  #           tierName: pro-main
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-upgrade' --instance-description 'test-cluster-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+  #         - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence With TLS
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-failover-tls' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+  #         - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence With TLS
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover-tls' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
 
-          # Enterprise
-          - name: Enterprise/Standalone - GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_standalone.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/SingleZone - GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_replication.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/MultiZone - GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_replication.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'  --instance-description 'test-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_cluster.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
-          - name: Enterprise/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_cluster.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+  #         # Enterprise
+  #         - name: Enterprise/Standalone - GCP/us-central1 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_standalone.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+  #         - name: Enterprise/SingleZone - GCP/us-central1 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_replication.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+  #         - name: Enterprise/MultiZone - GCP/us-central1 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_replication.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'  --instance-description 'test-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+  #         - name: Enterprise/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_cluster.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+  #         - name: Enterprise/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_cluster.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
 
-          # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Shards
-          #   if: "true"
-          #   testFile: test_cluster_shards.py
-          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          #   cloudProvider: gcp
-          #   cloudRegion: us-central1
-          #   subscriptionId: sub-GJPV3NoNC0
-          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-          #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-shards' --instance-description 'test-cluster-sz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-          # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Shards
-          #   if: "true"
-          #   testFile: test_cluster_shards.py
-          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          #   cloudProvider: gcp
-          #   cloudRegion: us-central1
-          #   subscriptionId: sub-GJPV3NoNC0
-          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-          #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-shards' --instance-description 'test-cluster-mz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-          # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Replicas
-          #   if: "true"
-          #   testFile: test_cluster_replicas.py
-          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          #   cloudProvider: gcp
-          #   cloudRegion: us-central1
-          #   subscriptionId: sub-GJPV3NoNC0
-          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-          #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-replicas' --instance-description 'test-cluster-sz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3'"
-          # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Replicas
-          #   if: "true"
-          #   testFile: test_cluster_replicas.py
-          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          #   cloudProvider: gcp
-          #   cloudRegion: us-central1
-          #   subscriptionId: sub-GJPV3NoNC0
-          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-          #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-replicas' --instance-description 'test-cluster-mz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3' --ensure-mz-distribution"
-          - name: PRO/SingleZone - GCP/us-central1 - Test add/remove replica
-            if: "true"
-            testFile: test_replication_replicas.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - GCP/us-central1 - Test add/remove replica
-            if: "true"
-            testFile: test_replication_replicas.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-            ###################### GCP private ######################
-          - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_cluster.py
-            runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type INTERNAL --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type INTERNAL --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-            ###################### AWS ######################
-          - name: Free - AWS/us-east-2 - Failover & Persistence
-            if: "true"
-            testFile: test_standalone.py
-            tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT }}
-            extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/Standalone - AWS/us-east-2 - Failover & Persistence
-            if: "true"
-            testFile: test_standalone.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-1' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - AWS/us-east-2 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover' --instance-description 'test-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - AWS/us-east-2 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-          - name: PRO/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-          # Enterprise
-          - name: Enterprise/Standalone - AWS/us-east-2 - Failover & Persistence
-            # Run only if is tag, or PR is ready for review
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_standalone.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/SingleZone - AWS/us-east-2 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_replication.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/MultiZone - AWS/us-east-2 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_replication.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'   --instance-description 'test-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_cluster.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
-          - name: Enterprise/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_cluster.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: aws
-            cloudRegion: us-east-2
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+  #         # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Shards
+  #         #   if: "true"
+  #         #   testFile: test_cluster_shards.py
+  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #         #   cloudProvider: gcp
+  #         #   cloudRegion: us-central1
+  #         #   subscriptionId: sub-GJPV3NoNC0
+  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #         #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-shards' --instance-description 'test-cluster-sz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+  #         # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Shards
+  #         #   if: "true"
+  #         #   testFile: test_cluster_shards.py
+  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #         #   cloudProvider: gcp
+  #         #   cloudRegion: us-central1
+  #         #   subscriptionId: sub-GJPV3NoNC0
+  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #         #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-shards' --instance-description 'test-cluster-mz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+  #         # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Replicas
+  #         #   if: "true"
+  #         #   testFile: test_cluster_replicas.py
+  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #         #   cloudProvider: gcp
+  #         #   cloudRegion: us-central1
+  #         #   subscriptionId: sub-GJPV3NoNC0
+  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #         #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-replicas' --instance-description 'test-cluster-sz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3'"
+  #         # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Replicas
+  #         #   if: "true"
+  #         #   testFile: test_cluster_replicas.py
+  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #         #   cloudProvider: gcp
+  #         #   cloudRegion: us-central1
+  #         #   subscriptionId: sub-GJPV3NoNC0
+  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #         #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-replicas' --instance-description 'test-cluster-mz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3' --ensure-mz-distribution"
+  #         - name: PRO/SingleZone - GCP/us-central1 - Test add/remove replica
+  #           if: "true"
+  #           testFile: test_replication_replicas.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/MultiZone - GCP/us-central1 - Test add/remove replica
+  #           if: "true"
+  #           testFile: test_replication_replicas.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #           ###################### GCP private ######################
+  #         - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type INTERNAL --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+  #         - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: gcp
+  #           cloudRegion: us-central1
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type INTERNAL --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #           ###################### AWS ######################
+  #         - name: Free - AWS/us-east-2 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_standalone.py
+  #           tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT }}
+  #           extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/Standalone - AWS/us-east-2 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_standalone.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-1' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/SingleZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover' --instance-description 'test-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/MultiZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_replication.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+  #         - name: PRO/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+  #         - name: PRO/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "true"
+  #           testFile: test_cluster.py
+  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+  #         # Enterprise
+  #         - name: Enterprise/Standalone - AWS/us-east-2 - Failover & Persistence
+  #           # Run only if is tag, or PR is ready for review
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_standalone.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+  #         - name: Enterprise/SingleZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_replication.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+  #         - name: Enterprise/MultiZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_replication.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'   --instance-description 'test-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+  #         - name: Enterprise/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_cluster.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+  #         - name: Enterprise/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
+  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+  #           testFile: test_cluster.py
+  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  #           cloudProvider: aws
+  #           cloudRegion: us-east-2
+  #           subscriptionId: sub-GJPV3NoNC0
+  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
 
-    steps:
-      - name: Checkout
-        if: matrix.instances.if == 'true' || matrix.instances.if == true
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  #   steps:
+  #     - name: Checkout
+  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup python
-        if: ${{ (matrix.instances.if == 'true' || matrix.instances.if == true) && !matrix.instances.runner_label }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
+  #     - name: Setup python
+  #       if: ${{ (matrix.instances.if == 'true' || matrix.instances.if == true) && !matrix.instances.runner_label }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: "3.x"
 
-      - name: Cache Poetry virtualenv
-        if: matrix.instances.if == 'true' || matrix.instances.if == true
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.poetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-
+  #     - name: Cache Poetry virtualenv
+  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
+  #       id: cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ~/.poetry/virtualenvs
+  #         key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-poetry-
 
-      - name: Install Poetry
-        if: steps.cache.outputs.cache-hit != true && (matrix.instances.if == 'true' || matrix.instances.if == true)
-        env:
-          if: ${{ matrix.instances.if }}
-          if_equal_bool: ${{ matrix.instances.if == true }}
-          if_equal_str: ${{ matrix.instances.if == 'true' }}
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+  #     - name: Install Poetry
+  #       if: steps.cache.outputs.cache-hit != true && (matrix.instances.if == 'true' || matrix.instances.if == true)
+  #       env:
+  #         if: ${{ matrix.instances.if }}
+  #         if_equal_bool: ${{ matrix.instances.if == true }}
+  #         if_equal_str: ${{ matrix.instances.if == 'true' }}
+  #       run: |
+  #         curl -sSL https://install.python-poetry.org | python3 -
 
-      - name: Install dependencies
-        if: matrix.instances.if == 'true' || matrix.instances.if == true
-        run: |
-          export PATH="~/.local/bin:$PATH"
-          poetry install
+  #     - name: Install dependencies
+  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
+  #       run: |
+  #         export PATH="~/.local/bin:$PATH"
+  #         poetry install
 
-      - name: ${{ matrix.instances.name }}
-        if: matrix.instances.if == 'true' || matrix.instances.if == true
-        env:
-          SERVICE_ID: ${{ matrix.instances.serviceId }}
-          ENVIRONMENT_ID: ${{ matrix.instances.environmentId }}
-          CLOUD_PROVIDER: ${{ matrix.instances.cloudProvider }}
-          CLOUD_REGION: ${{ matrix.instances.cloudRegion }}
-          extraParams: ${{ matrix.instances.extraParams }}
-          SUBSCRIPTION_ID: ${{ matrix.instances.subscriptionId }}
-          REF_NAME: ${{ matrix.instances.tierName }}
-        run: |
-          export PATH="~/.local/bin:$PATH"
-          poetry run python -u ./omnistrate_tests/${{ matrix.instances.testFile }} ${{ secrets.OMNISTRATE_USERNAME }} ${{ secrets.OMNISTRATE_PASSWORD }} ${{ env.CLOUD_PROVIDER }} ${{ env.CLOUD_REGION }} --service-id ${{ env.SERVICE_ID }} --environment-id ${{ env.ENVIRONMENT_ID }} ${{ env.extraParams }}
+  #     - name: ${{ matrix.instances.name }}
+  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
+  #       env:
+  #         SERVICE_ID: ${{ matrix.instances.serviceId }}
+  #         ENVIRONMENT_ID: ${{ matrix.instances.environmentId }}
+  #         CLOUD_PROVIDER: ${{ matrix.instances.cloudProvider }}
+  #         CLOUD_REGION: ${{ matrix.instances.cloudRegion }}
+  #         extraParams: ${{ matrix.instances.extraParams }}
+  #         SUBSCRIPTION_ID: ${{ matrix.instances.subscriptionId }}
+  #         REF_NAME: ${{ matrix.instances.tierName }}
+  #       run: |
+  #         export PATH="~/.local/bin:$PATH"
+  #         poetry run python -u ./omnistrate_tests/${{ matrix.instances.testFile }} ${{ secrets.OMNISTRATE_USERNAME }} ${{ secrets.OMNISTRATE_PASSWORD }} ${{ env.CLOUD_PROVIDER }} ${{ env.CLOUD_REGION }} --service-id ${{ env.SERVICE_ID }} --environment-id ${{ env.ENVIRONMENT_ID }} ${{ env.extraParams }}
 
-  # Runs only if the branch is 'main' or 'v*'
-  delete-networks:
-    runs-on: ubuntu-latest
-    needs: test
-    if: contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  # # Runs only if the branch is 'main' or 'v*'
+  # delete-networks:
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   if: contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main')
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Delete Omnistrate Custom Network - GCP
-        uses: ./.github/actions/delete-omnistrate-custom-network
-        continue-on-error: true
-        with:
-          username: ${{ secrets.OMNISTRATE_USERNAME }}
-          password: ${{ secrets.OMNISTRATE_PASSWORD }}
-          custom_network_name: ${{ env.GCP_NETWORK_NAME }}
+  #     - name: Delete Omnistrate Custom Network - GCP
+  #       uses: ./.github/actions/delete-omnistrate-custom-network
+  #       continue-on-error: true
+  #       with:
+  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
+  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
+  #         custom_network_name: ${{ env.GCP_NETWORK_NAME }}
 
-      - name: Delete Omnistrate Custom Network - AWS
-        continue-on-error: true
-        uses: ./.github/actions/delete-omnistrate-custom-network
-        with:
-          username: ${{ secrets.OMNISTRATE_USERNAME }}
-          password: ${{ secrets.OMNISTRATE_PASSWORD }}
-          custom_network_name: ${{ env.AWS_NETWORK_NAME }}
+  #     - name: Delete Omnistrate Custom Network - AWS
+  #       continue-on-error: true
+  #       uses: ./.github/actions/delete-omnistrate-custom-network
+  #       with:
+  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
+  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
+  #         custom_network_name: ${{ env.AWS_NETWORK_NAME }}
 
   cleanup-runner:
     needs: test

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -464,7 +464,250 @@ jobs:
             serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
             extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          ###################### GCP PRIVATE ######################
+          - name: Free - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_standalone.py
+            tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'free' --replica-id 'node-f-0' --network-type PRIVATE --instance-name 'test-free-failover-private' --instance-description 'test-free-failover-private' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_standalone.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --network-type PRIVATE --instance-name 'test-standalone-failover-private' --instance-description 'test-standalone-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-private' --network-type PRIVATE --instance-description 'test-sz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type PRIVATE --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_standalone.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --network-type PRIVATE --instance-name 'test-standalone-failover-tls-private' --instance-description 'test-standalone-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-tls-private' --network-type PRIVATE --instance-description 'test-sz-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls-private' --network-type PRIVATE --instance-description 'test-mz-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Update Memory
+            if: "true"
+            testFile: test_update_memory.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-update-memory-private' --network-type PRIVATE  --instance-description 'test-standalone-update-memory-private' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Update Memory
+            if: "true"
+            testFile: test_update_memory.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-update-memory-private'  --network-type PRIVATE --instance-description 'test-replication-update-memory-private' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Update Memory
+            if: "true"
+            testFile: test_update_memory.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-update-memory-private'  --network-type PRIVATE --instance-description 'test-cluster-update-memory-private' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+          - name: PRO/Standalone - PRIVATE/GCP/us-central1 - Upgrade Version
+            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+            testFile: test_upgrade_version.py
+            tierName: pro-main
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-upgrade-private' --network-type PRIVATE --instance-description 'test-standalone-upgrade-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Upgrade Version
+            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+            testFile: test_upgrade_version.py
+            tierName: pro-main
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-upgrade-private' --network-type PRIVATE --instance-description 'test-replication-upgrade-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Upgrade Version
+            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+            testFile: test_upgrade_version.py
+            tierName: pro-main
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-upgrade-private' --network-type PRIVATE --instance-description 'test-cluster-upgrade-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --network-type PRIVATE --instance-name 'test-cluster-sz-failover-private' --instance-description 'test-cluster-sz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+          - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1' --network-type PRIVATE --instance-name 'test-cluster-sz-failover-tls-private' --instance-description 'test-cluster-sz-failover-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+          - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-failover-tls-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
 
+          # Enterprise
+          - name: Enterprise/Standalone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_standalone.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --network-type PRIVATE --instance-name 'test-standalone-enterprise-failover-private' --instance-description 'test-standalone-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_replication.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover-private' --network-type PRIVATE --instance-description 'test-sz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_replication.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover-private' --network-type PRIVATE --instance-description 'test-mz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_cluster.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1' --network-type PRIVATE --instance-name 'test-cluster-sz-enterprise-failover-private' --instance-description 'test-cluster-sz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+          - name: Enterprise/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_cluster.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-enterprise-failover-private' --instance-description 'test-cluster-mz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+
+          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Test add/remove replica
+            if: "true"
+            testFile: test_replication_replicas.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica-private' --network-type PRIVATE --instance-description 'test-replication-add-remove-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Test add/remove replica
+            if: "true"
+            testFile: test_replication_replicas.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --network-type PRIVATE --instance-name 'test-mz-add-remove-replica-private' --instance-description 'test-replication-add-remove-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
             ###################### AWS ######################
           - name: Free - AWS/us-east-2 - Failover & Persistence
             if: "true"

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -713,7 +713,7 @@ jobs:
   #         custom_network_name: ${{ env.AWS_NETWORK_NAME }}
 
   cleanup-runner:
-    needs: test
+    #needs: test
     if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -24,6 +24,38 @@ env:
   AWS_NETWORK_NAME: aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
 
 jobs:
+  create-runners:
+    strategy:
+      matrix:
+        machines:
+          - name: replication-runner-private-gcp
+            machine_type: e2-standard-4
+            runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
+            arm: false
+            image: projects/app-plane-dev-f7a2434f/global/images/gh-runner-debian
+          - name: cluster-runner-private-gcp
+            machine_type: e2-standard-4
+            runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
+            arm: false
+            image: projects/app-plane-dev-f7a2434f/global/images/gh-runner-debian
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create runners
+        id: create-runner
+        uses: FalkorDB/gce-github-runner@install_docker
+        with:
+          token: ${{ secrets.GH_SA_TOKEN }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          machine_zone: ${{ vars.GCP_ZONE }}
+          network: n-hcjx5tis6bc
+          subnet: s-hcjx5tis6bc-pod
+          disk_size: 100
+          machine_type: ${{ matrix.machines.machine_type }}
+          runner_label: ${{ matrix.machines.runner_label }}
+          arm: ${{ matrix.machines.arm }}
+          image: ${{ matrix.machines.image }}
+
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
@@ -174,8 +206,8 @@ jobs:
           name: ${{ env.AWS_NETWORK_NAME }}
 
   test:
-    needs: create-custom-networks
-    runs-on: ubuntu-latest
+    needs: [create-custom-networks, create-runners]
+    runs-on: ${{ matrix.instances.runner_label || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -464,132 +496,29 @@ jobs:
             serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
             extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          ###################### GCP PRIVATE ######################
-          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-private' --network-type PRIVATE --instance-description 'test-sz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type PRIVATE --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-tls-private' --network-type PRIVATE --instance-description 'test-sz-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_replication.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls-private' --network-type PRIVATE --instance-description 'test-mz-failover-tls-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-
-          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --network-type PRIVATE --instance-name 'test-cluster-sz-failover-private' --instance-description 'test-cluster-sz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+            ###################### GCP private ######################
           - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
             if: "true"
             testFile: test_cluster.py
+            runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
             tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
             cloudProvider: gcp
             cloudRegion: us-central1
             subscriptionId: sub-GJPV3NoNC0
             serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-          - name: PRO/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type INTERNAL --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
             if: "true"
-            testFile: test_cluster.py
+            testFile: test_replication.py
+            runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
             tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
             cloudProvider: gcp
             cloudRegion: us-central1
             subscriptionId: sub-GJPV3NoNC0
             serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
             environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1' --network-type PRIVATE --instance-name 'test-cluster-sz-failover-tls-private' --instance-description 'test-cluster-sz-failover-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-          - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence With TLS
-            if: "true"
-            testFile: test_cluster.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-failover-tls-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-
-          # Enterprise
-
-          - name: Enterprise/SingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_replication.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover-private' --network-type PRIVATE --instance-description 'test-sz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_replication.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover-private' --network-type PRIVATE --instance-description 'test-mz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-          - name: Enterprise/ClusterSingleZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_cluster.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1' --network-type PRIVATE --instance-name 'test-cluster-sz-enterprise-failover-private' --instance-description 'test-cluster-sz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
-          - name: Enterprise/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-            testFile: test_cluster.py
-            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type PRIVATE --instance-name 'test-cluster-mz-enterprise-failover-private' --instance-description 'test-cluster-mz-enterprise-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
-
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type INTERNAL --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
             ###################### AWS ######################
           - name: Free - AWS/us-east-2 - Failover & Persistence
             if: "true"
@@ -712,7 +641,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup python
-        if: matrix.instances.if == 'true' || matrix.instances.if == true
+        if: ${{ (matrix.instances.if == 'true' || matrix.instances.if == true) && !matrix.instances.runner_label }}
         uses: actions/setup-python@v2
         with:
           python-version: "3.x"
@@ -738,7 +667,9 @@ jobs:
 
       - name: Install dependencies
         if: matrix.instances.if == 'true' || matrix.instances.if == true
-        run: poetry install
+        run: |
+          export PATH="~/.local/bin:$PATH"
+          poetry install
 
       - name: ${{ matrix.instances.name }}
         if: matrix.instances.if == 'true' || matrix.instances.if == true
@@ -751,6 +682,7 @@ jobs:
           SUBSCRIPTION_ID: ${{ matrix.instances.subscriptionId }}
           REF_NAME: ${{ matrix.instances.tierName }}
         run: |
+          export PATH="~/.local/bin:$PATH"
           poetry run python -u ./omnistrate_tests/${{ matrix.instances.testFile }} ${{ secrets.OMNISTRATE_USERNAME }} ${{ secrets.OMNISTRATE_PASSWORD }} ${{ env.CLOUD_PROVIDER }} ${{ env.CLOUD_REGION }} --service-id ${{ env.SERVICE_ID }} --environment-id ${{ env.ENVIRONMENT_ID }} ${{ env.extraParams }}
 
   # Runs only if the branch is 'main' or 'v*'
@@ -779,3 +711,21 @@ jobs:
           username: ${{ secrets.OMNISTRATE_USERNAME }}
           password: ${{ secrets.OMNISTRATE_PASSWORD }}
           custom_network_name: ${{ env.AWS_NETWORK_NAME }}
+
+  cleanup-runner:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - machine_label: cluster-${{ github.run_id }}-${{ github.run_number }}
+          - machine_label: replication-${{ github.run_id }}-${{ github.run_number }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup-runner
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          zone: ${{ vars.GCP_ZONE }}
+          instance_label: ${{ matrix.platform.machine_label }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -56,664 +56,664 @@ jobs:
           arm: ${{ matrix.machines.arm }}
           image: ${{ matrix.machines.image }}
 
-  # build-and-push:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       include:
-  #         - dockerfile: ./falkordb-node/Dockerfile
-  #           image-name: falkordb-node
-  #         - dockerfile: ./falkordb-cluster/Dockerfile
-  #           image-name: falkordb-cluster
-  #         - dockerfile: ./falkordb-cluster-rebalance/Dockerfile
-  #           image-name: falkordb-cluster-rebalance
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - dockerfile: ./falkordb-node/Dockerfile
+            image-name: falkordb-node
+          - dockerfile: ./falkordb-cluster/Dockerfile
+            image-name: falkordb-cluster
+          - dockerfile: ./falkordb-cluster-rebalance/Dockerfile
+            image-name: falkordb-cluster-rebalance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Build and push
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         build-args: FALKORDB_VERSION=${{ env.FALKORDB_VERSION }}
-  #         context: .
-  #         file: ${{ matrix.dockerfile }}
-  #         push: true
-  #         tags: falkordb/${{ matrix.image-name }}:dev-${{ github.event.head_commit.id || github.run_id }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          build-args: FALKORDB_VERSION=${{ env.FALKORDB_VERSION }}
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: falkordb/${{ matrix.image-name }}:dev-${{ github.event.head_commit.id || github.run_id }}
 
-  # omnistrate-update-plans:
-  #   needs: build-and-push
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     max-parallel: 1
-  #     matrix:
-  #       plans:
-  #         - service-name: FalkorDB
-  #           plan-name: FalkorDB Free
-  #           file: omnistrate.free.yaml
-  #           key: free
-  #           tier-name: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #         - service-name: FalkorDB
-  #           plan-name: FalkorDB Pro
-  #           file: omnistrate.pro.yaml
-  #           key: pro
-  #           tier-name: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
-  #         - service-name: FalkorDB
-  #           plan-name: FalkorDB Enterprise
-  #           file: omnistrate.enterprise.yaml
-  #           key: enterprise
-  #           tier-name: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  omnistrate-update-plans:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        plans:
+          - service-name: FalkorDB
+            plan-name: FalkorDB Free
+            file: omnistrate.free.yaml
+            key: free
+            tier-name: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          - service-name: FalkorDB
+            plan-name: FalkorDB Pro
+            file: omnistrate.pro.yaml
+            key: pro
+            tier-name: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
+          - service-name: FalkorDB
+            plan-name: FalkorDB Enterprise
+            file: omnistrate.enterprise.yaml
+            key: enterprise
+            tier-name: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref ||  github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  #     - name: Replace Variables
-  #       run: |
-  #         sed -i 's/$GcpProjectId/${{ vars.GCP_PROJECT_ID }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's/$GcpProjectNumber/${{ vars.GCP_PROJECT_NUMBER }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's/$GcpServiceAccountEmail/${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's/$AwsAccountId/${{ vars.AWS_ACCOUNT_ID }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's|$AwsBootstrapRoleAccountArn|${{ vars.AWS_BOOTSTRAP_ROLE_ACCOUNT_ARN }}|g' ${{ matrix.plans.file }}
-  #         sed -i 's/$FalkorDBNodeImage/falkordb\/${{ env.NODE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's/$FalkorDBClusterImage/falkordb\/${{ env.CLUSTER_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's/$FalkorDBClusterRebalanceImage/falkordb\/${{ env.CLUSTER_REBALANCE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
-  #         sed -i 's/${{ matrix.plans.plan-name }}/${{ matrix.plans.tier-name }}/g' ${{ matrix.plans.file }}
+      - name: Replace Variables
+        run: |
+          sed -i 's/$GcpProjectId/${{ vars.GCP_PROJECT_ID }}/g' ${{ matrix.plans.file }}
+          sed -i 's/$GcpProjectNumber/${{ vars.GCP_PROJECT_NUMBER }}/g' ${{ matrix.plans.file }}
+          sed -i 's/$GcpServiceAccountEmail/${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}/g' ${{ matrix.plans.file }}
+          sed -i 's/$AwsAccountId/${{ vars.AWS_ACCOUNT_ID }}/g' ${{ matrix.plans.file }}
+          sed -i 's|$AwsBootstrapRoleAccountArn|${{ vars.AWS_BOOTSTRAP_ROLE_ACCOUNT_ARN }}|g' ${{ matrix.plans.file }}
+          sed -i 's/$FalkorDBNodeImage/falkordb\/${{ env.NODE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
+          sed -i 's/$FalkorDBClusterImage/falkordb\/${{ env.CLUSTER_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
+          sed -i 's/$FalkorDBClusterRebalanceImage/falkordb\/${{ env.CLUSTER_REBALANCE_IMAGE_NAME }}:dev-${{ github.event.head_commit.id || github.run_id }}/g' ${{ matrix.plans.file }}
+          sed -i 's/${{ matrix.plans.plan-name }}/${{ matrix.plans.tier-name }}/g' ${{ matrix.plans.file }}
 
-  #     - name: Remove custom metrics for testing
-  #       run: |
-  #         yq eval 'del(.x-omnistrate-integrations[1].omnistrateMetrics) | .x-omnistrate-integrations |= map(select(type != "!!map" or length > 0))' ${{ matrix.plans.file }} > ${{ matrix.plans.file }}.tmp
-  #         mv ${{ matrix.plans.file }}.tmp ${{ matrix.plans.file }}
+      - name: Remove custom metrics for testing
+        run: |
+          yq eval 'del(.x-omnistrate-integrations[1].omnistrateMetrics) | .x-omnistrate-integrations |= map(select(type != "!!map" or length > 0))' ${{ matrix.plans.file }} > ${{ matrix.plans.file }}.tmp
+          mv ${{ matrix.plans.file }}.tmp ${{ matrix.plans.file }}
       
-  #     - name: Upload yaml as artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: ${{ matrix.plans.file }}
-  #         path: ${{ matrix.plans.file }}
+      - name: Upload yaml as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.plans.file }}
+          path: ${{ matrix.plans.file }}
 
-  #     - name: Create FALKORDB_PASSWORD/ADMIN_PASSWORD files
-  #       run: |
-  #         export sec=$(grep '^secrets' omnistrate.free.yaml)
-  #         if [[ -n "$sec" ]];then
-  #           mkdir -p secrets || { echo "Failed to create secrets directory"; exit 1; }
-  #           echo '{{ $var.falkordbPassword }}' > ./secrets/falkordbpassword || { echo "Failed to write falkordbpassword"; exit 1; }
-  #           echo '{{ $func.random(string, 16, $sys.deterministicSeedValue) }}' > ./secrets/adminpassword || { echo "Failed to write adminpassword"; exit 1; }
-  #           echo '{{ $var.adminPassword }}' > ./secrets/grafana_admin_password || { echo "Failed to write grafana_admin_password"; exit 1; }
-  #           echo '{{ $func.random(string, 16, $sys.deterministicSeedValue)  }}' > ./secrets/grafana_secret_key || { echo "Failed to write grafana_secret_key"; exit 1; }
-  #           echo '{{ $var.smtpPassword }}' > ./secrets/grafana_smtp_password || { echo "Failed to write grafana_smtp_password"; exit 1; }
-  #         else
-  #           echo "secrets option was not used"
-  #           exit 0
-  #         fi
+      - name: Create FALKORDB_PASSWORD/ADMIN_PASSWORD files
+        run: |
+          export sec=$(grep '^secrets' omnistrate.free.yaml)
+          if [[ -n "$sec" ]];then
+            mkdir -p secrets || { echo "Failed to create secrets directory"; exit 1; }
+            echo '{{ $var.falkordbPassword }}' > ./secrets/falkordbpassword || { echo "Failed to write falkordbpassword"; exit 1; }
+            echo '{{ $func.random(string, 16, $sys.deterministicSeedValue) }}' > ./secrets/adminpassword || { echo "Failed to write adminpassword"; exit 1; }
+            echo '{{ $var.adminPassword }}' > ./secrets/grafana_admin_password || { echo "Failed to write grafana_admin_password"; exit 1; }
+            echo '{{ $func.random(string, 16, $sys.deterministicSeedValue)  }}' > ./secrets/grafana_secret_key || { echo "Failed to write grafana_secret_key"; exit 1; }
+            echo '{{ $var.smtpPassword }}' > ./secrets/grafana_smtp_password || { echo "Failed to write grafana_smtp_password"; exit 1; }
+          else
+            echo "secrets option was not used"
+            exit 0
+          fi
 
-  #     - name: Update Omnistrate plan
-  #       uses: ./.github/actions/update-omnistrate-plan
-  #       id: update_omnistrate_plan
-  #       with:
-  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
-  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
-  #         file: ${{ matrix.plans.file }}
-  #         service-name: ${{ matrix.plans.service-name }}
-  #         environment: testing
-  #         environment-type: qa
-  #         release-description: dev-${{ github.event.head_commit.id || github.run_id }}
+      - name: Update Omnistrate plan
+        uses: ./.github/actions/update-omnistrate-plan
+        id: update_omnistrate_plan
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          file: ${{ matrix.plans.file }}
+          service-name: ${{ matrix.plans.service-name }}
+          environment: testing
+          environment-type: qa
+          release-description: dev-${{ github.event.head_commit.id || github.run_id }}
 
-  # create-custom-networks:
-  #   needs: omnistrate-update-plans
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  create-custom-networks:
+    needs: omnistrate-update-plans
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  #     - name: Create Omnistrate Custom Network - GCP
-  #       if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
-  #       uses: ./.github/actions/create-omnistrate-custom-network
-  #       id: create_custom_network_gcp
-  #       with:
-  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
-  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
-  #         cloud_provider: gcp
-  #         region: us-central1
-  #         cidr: "73.0.0.0/16"
-  #         name: ${{ env.GCP_NETWORK_NAME}}
+      - name: Create Omnistrate Custom Network - GCP
+        if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+        uses: ./.github/actions/create-omnistrate-custom-network
+        id: create_custom_network_gcp
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          cloud_provider: gcp
+          region: us-central1
+          cidr: "73.0.0.0/16"
+          name: ${{ env.GCP_NETWORK_NAME}}
 
-  #     - name: Create Omnistrate Custom Network - AWS
-  #       if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
-  #       uses: ./.github/actions/create-omnistrate-custom-network
-  #       id: create_custom_network_aws
-  #       with:
-  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
-  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
-  #         cloud_provider: aws
-  #         region: us-east-2
-  #         cidr: "73.0.0.0/16"
-  #         name: ${{ env.AWS_NETWORK_NAME }}
+      - name: Create Omnistrate Custom Network - AWS
+        if: ${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+        uses: ./.github/actions/create-omnistrate-custom-network
+        id: create_custom_network_aws
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          cloud_provider: aws
+          region: us-east-2
+          cidr: "73.0.0.0/16"
+          name: ${{ env.AWS_NETWORK_NAME }}
 
-  # test:
-  #   needs: [create-custom-networks, create-runners]
-  #   runs-on: ${{ matrix.instances.runner_label || 'ubuntu-latest' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       instances:
-  #         ###################### GCP ######################
-  #         - name: Free - GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_standalone.py
-  #           tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_standalone.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover'  --instance-description 'test-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence With TLS
-  #           if: "true"
-  #           testFile: test_standalone.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover-tls' --instance-description 'test-standalone-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence With TLS
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-tls'  --instance-description 'test-sz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence With TLS
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls' --instance-description 'test-mz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/Standalone - GCP/us-central1 - Update Memory
-  #           if: "true"
-  #           testFile: test_update_memory.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-update-memory'  --instance-description 'test-standalone-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/SingleZone - GCP/us-central1 - Update Memory
-  #           if: "true"
-  #           testFile: test_update_memory.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-update-memory'  --instance-description 'test-replication-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Update Memory
-  #           if: "true"
-  #           testFile: test_update_memory.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-update-memory'  --instance-description 'test-cluster-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
-  #         - name: PRO/Standalone - GCP/us-central1 - Upgrade Version
-  #           if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-  #           testFile: test_upgrade_version.py
-  #           tierName: pro-main
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-upgrade' --instance-description 'test-standalone-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/SingleZone - GCP/us-central1 - Upgrade Version
-  #           if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-  #           testFile: test_upgrade_version.py
-  #           tierName: pro-main
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-upgrade' --instance-description 'test-replication-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Upgrade Version
-  #           if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
-  #           testFile: test_upgrade_version.py
-  #           tierName: pro-main
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-upgrade' --instance-description 'test-cluster-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
-  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-  #         - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-  #         - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence With TLS
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-failover-tls' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-  #         - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence With TLS
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover-tls' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+  test:
+    needs: [create-custom-networks, create-runners]
+    runs-on: ${{ matrix.instances.runner_label || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        instances:
+          ###################### GCP ######################
+          - name: Free - GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_standalone.py
+            tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_standalone.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover'  --instance-description 'test-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_standalone.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-failover-tls' --instance-description 'test-standalone-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover-tls'  --instance-description 'test-sz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-tls' --instance-description 'test-mz-failover-tls' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - GCP/us-central1 - Update Memory
+            if: "true"
+            testFile: test_update_memory.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-update-memory'  --instance-description 'test-standalone-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - GCP/us-central1 - Update Memory
+            if: "true"
+            testFile: test_update_memory.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-update-memory'  --instance-description 'test-replication-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/ClusterSingleZone - GCP/us-central1 - Update Memory
+            if: "true"
+            testFile: test_update_memory.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-update-memory'  --instance-description 'test-cluster-update-memory' --instance-type 'e2-medium' --new-instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+          - name: PRO/Standalone - GCP/us-central1 - Upgrade Version
+            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+            testFile: test_upgrade_version.py
+            tierName: pro-main
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --instance-name 'test-standalone-upgrade' --instance-description 'test-standalone-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - GCP/us-central1 - Upgrade Version
+            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+            testFile: test_upgrade_version.py
+            tierName: pro-main
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-replication-upgrade' --instance-description 'test-replication-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/ClusterSingleZone - GCP/us-central1 - Upgrade Version
+            if: ${{ contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main') }}
+            testFile: test_upgrade_version.py
+            tierName: pro-main
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-upgrade' --instance-description 'test-cluster-upgrade' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --cluster-replicas '1' --host-count '6'"
+          - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+          - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+          - name: PRO/ClusterSingleZone - GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-failover-tls' --instance-description 'test-cluster-sz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+          - name: PRO/ClusterMultiZone - GCP/us-central1 - Failover & Persistence With TLS
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-failover-tls' --instance-description 'test-cluster-mz-failover' --instance-type 'e2-medium' --storage-size '30' --tls --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
 
-  #         # Enterprise
-  #         - name: Enterprise/Standalone - GCP/us-central1 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_standalone.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-  #         - name: Enterprise/SingleZone - GCP/us-central1 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_replication.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-  #         - name: Enterprise/MultiZone - GCP/us-central1 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_replication.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'  --instance-description 'test-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-  #         - name: Enterprise/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_cluster.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
-  #         - name: Enterprise/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_cluster.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+          # Enterprise
+          - name: Enterprise/Standalone - GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_standalone.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/SingleZone - GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_replication.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/MultiZone - GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_replication.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'  --instance-description 'test-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/ClusterSingleZone - GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_cluster.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+          - name: Enterprise/ClusterMultiZone - GCP/us-central1 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_cluster.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=gcp-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
 
-  #         # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Shards
-  #         #   if: "true"
-  #         #   testFile: test_cluster_shards.py
-  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #         #   cloudProvider: gcp
-  #         #   cloudRegion: us-central1
-  #         #   subscriptionId: sub-GJPV3NoNC0
-  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #         #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-shards' --instance-description 'test-cluster-sz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-  #         # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Shards
-  #         #   if: "true"
-  #         #   testFile: test_cluster_shards.py
-  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #         #   cloudProvider: gcp
-  #         #   cloudRegion: us-central1
-  #         #   subscriptionId: sub-GJPV3NoNC0
-  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #         #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-shards' --instance-description 'test-cluster-mz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-  #         # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Replicas
-  #         #   if: "true"
-  #         #   testFile: test_cluster_replicas.py
-  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #         #   cloudProvider: gcp
-  #         #   cloudRegion: us-central1
-  #         #   subscriptionId: sub-GJPV3NoNC0
-  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #         #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-replicas' --instance-description 'test-cluster-sz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3'"
-  #         # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Replicas
-  #         #   if: "true"
-  #         #   testFile: test_cluster_replicas.py
-  #         #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #         #   cloudProvider: gcp
-  #         #   cloudRegion: us-central1
-  #         #   subscriptionId: sub-GJPV3NoNC0
-  #         #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #         #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #         #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-replicas' --instance-description 'test-cluster-mz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3' --ensure-mz-distribution"
-  #         - name: PRO/SingleZone - GCP/us-central1 - Test add/remove replica
-  #           if: "true"
-  #           testFile: test_replication_replicas.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/MultiZone - GCP/us-central1 - Test add/remove replica
-  #           if: "true"
-  #           testFile: test_replication_replicas.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #           ###################### GCP private ######################
-  #         - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type INTERNAL --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-  #         - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: gcp
-  #           cloudRegion: us-central1
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type INTERNAL --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #           ###################### AWS ######################
-  #         - name: Free - AWS/us-east-2 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_standalone.py
-  #           tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT }}
-  #           extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/Standalone - AWS/us-east-2 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_standalone.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-1' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/SingleZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover' --instance-description 'test-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/MultiZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_replication.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-  #         - name: PRO/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
-  #         - name: PRO/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "true"
-  #           testFile: test_cluster.py
-  #           tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
-  #         # Enterprise
-  #         - name: Enterprise/Standalone - AWS/us-east-2 - Failover & Persistence
-  #           # Run only if is tag, or PR is ready for review
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_standalone.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-  #         - name: Enterprise/SingleZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_replication.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-  #         - name: Enterprise/MultiZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_replication.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'   --instance-description 'test-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
-  #         - name: Enterprise/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_cluster.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
-  #         - name: Enterprise/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
-  #           if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
-  #           testFile: test_cluster.py
-  #           tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-  #           cloudProvider: aws
-  #           cloudRegion: us-east-2
-  #           subscriptionId: sub-GJPV3NoNC0
-  #           serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-  #           environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-  #           extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+          # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Shards
+          #   if: "true"
+          #   testFile: test_cluster_shards.py
+          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          #   cloudProvider: gcp
+          #   cloudRegion: us-central1
+          #   subscriptionId: sub-GJPV3NoNC0
+          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+          #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-shards' --instance-description 'test-cluster-sz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+          # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Shards
+          #   if: "true"
+          #   testFile: test_cluster_shards.py
+          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          #   cloudProvider: gcp
+          #   cloudRegion: us-central1
+          #   subscriptionId: sub-GJPV3NoNC0
+          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+          #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-shards' --instance-description 'test-cluster-mz-shards' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+          # - name: PRO/ClusterSingleZone - GCP/us-central1 - Add/Remove Replicas
+          #   if: "true"
+          #   testFile: test_cluster_replicas.py
+          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          #   cloudProvider: gcp
+          #   cloudRegion: us-central1
+          #   subscriptionId: sub-GJPV3NoNC0
+          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+          #   extraParams: "--resource-key 'cluster-Single-Zone' --instance-name 'test-cluster-sz-replicas' --instance-description 'test-cluster-sz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3'"
+          # - name: PRO/ClusterMultiZone - GCP/us-central1 - Add/Remove Replicas
+          #   if: "true"
+          #   testFile: test_cluster_replicas.py
+          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          #   cloudProvider: gcp
+          #   cloudRegion: us-central1
+          #   subscriptionId: sub-GJPV3NoNC0
+          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+          #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-replicas' --instance-description 'test-cluster-mz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3' --ensure-mz-distribution"
+          - name: PRO/SingleZone - GCP/us-central1 - Test add/remove replica
+            if: "true"
+            testFile: test_replication_replicas.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - GCP/us-central1 - Test add/remove replica
+            if: "true"
+            testFile: test_replication_replicas.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+            ###################### GCP private ######################
+          - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4' --network-type INTERNAL --instance-name 'test-cluster-mz-failover-private' --instance-description 'test-cluster-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+          - name: PRO/MultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: gcp
+            cloudRegion: us-central1
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover-private' --network-type INTERNAL --instance-description 'test-mz-failover-private' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+            ###################### AWS ######################
+          - name: Free - AWS/us-east-2 - Failover & Persistence
+            if: "true"
+            testFile: test_standalone.py
+            tierName: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT }}
+            extraParams: "--resource-key 'free' --replica-id 'node-f-0' --instance-name 'test-free-failover' --instance-description 'test-free-failover' --instance-type 'none' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/Standalone - AWS/us-east-2 - Failover & Persistence
+            if: "true"
+            testFile: test_standalone.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-1' --instance-name 'test-standalone-failover' --instance-description 'test-standalone-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/SingleZone - AWS/us-east-2 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-failover' --instance-description 'test-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/MultiZone - AWS/us-east-2 - Failover & Persistence
+            if: "true"
+            testFile: test_replication.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-failover' --instance-description 'test-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          - name: PRO/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'  --instance-name 'test-cluster-sz-failover' --instance-description 'test-cluster-sz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1'"
+          - name: PRO/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
+            if: "true"
+            testFile: test_cluster.py
+            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'  --instance-name 'test-cluster-mz-failover' --instance-description 'test-cluster-mz-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution"
+          # Enterprise
+          - name: Enterprise/Standalone - AWS/us-east-2 - Failover & Persistence
+            # Run only if is tag, or PR is ready for review
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_standalone.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'standalone' --replica-id 'node-s-0' --instance-name 'test-standalone-enterprise-failover' --instance-description 'test-standalone-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/SingleZone - AWS/us-east-2 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_replication.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'single-Zone' --instance-name 'test-sz-enterprise-failover'  --instance-description 'test-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/MultiZone - AWS/us-east-2 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_replication.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'multi-Zone' --instance-name 'test-mz-enterprise-failover'   --instance-description 'test-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
+          - name: Enterprise/ClusterSingleZone - AWS/us-east-2 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_cluster.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Single-Zone' --replica-id 'cluster-sz-1'   --instance-name 'test-cluster-sz-enterprise-failover' --instance-description 'test-cluster-sz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
+          - name: Enterprise/ClusterMultiZone - AWS/us-east-2 - Failover & Persistence
+            if: "${{ contains(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}"
+            testFile: test_cluster.py
+            tierName: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+            cloudProvider: aws
+            cloudRegion: us-east-2
+            subscriptionId: sub-GJPV3NoNC0
+            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+            extraParams: "--resource-key 'cluster-Multi-Zone' --replica-id 'cluster-mz-4'   --instance-name 'test-cluster-mz-enterprise-failover' --instance-description 'test-cluster-mz-enterprise-failover' --instance-type 't2.medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --ensure-mz-distribution --custom-network=aws-network-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }} --deployment-create-timeout-seconds 4800"
 
-  #   steps:
-  #     - name: Checkout
-  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Checkout
+        if: matrix.instances.if == 'true' || matrix.instances.if == true
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  #     - name: Setup python
-  #       if: ${{ (matrix.instances.if == 'true' || matrix.instances.if == true) && !matrix.instances.runner_label }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: "3.x"
+      - name: Setup python
+        if: ${{ (matrix.instances.if == 'true' || matrix.instances.if == true) && !matrix.instances.runner_label }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
 
-  #     - name: Cache Poetry virtualenv
-  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
-  #       id: cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: ~/.poetry/virtualenvs
-  #         key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-poetry-
+      - name: Cache Poetry virtualenv
+        if: matrix.instances.if == 'true' || matrix.instances.if == true
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.poetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
 
-  #     - name: Install Poetry
-  #       if: steps.cache.outputs.cache-hit != true && (matrix.instances.if == 'true' || matrix.instances.if == true)
-  #       env:
-  #         if: ${{ matrix.instances.if }}
-  #         if_equal_bool: ${{ matrix.instances.if == true }}
-  #         if_equal_str: ${{ matrix.instances.if == 'true' }}
-  #       run: |
-  #         curl -sSL https://install.python-poetry.org | python3 -
+      - name: Install Poetry
+        if: steps.cache.outputs.cache-hit != true && (matrix.instances.if == 'true' || matrix.instances.if == true)
+        env:
+          if: ${{ matrix.instances.if }}
+          if_equal_bool: ${{ matrix.instances.if == true }}
+          if_equal_str: ${{ matrix.instances.if == 'true' }}
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
 
-  #     - name: Install dependencies
-  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
-  #       run: |
-  #         export PATH="~/.local/bin:$PATH"
-  #         poetry install
+      - name: Install dependencies
+        if: matrix.instances.if == 'true' || matrix.instances.if == true
+        run: |
+          export PATH="~/.local/bin:$PATH"
+          poetry install
 
-  #     - name: ${{ matrix.instances.name }}
-  #       if: matrix.instances.if == 'true' || matrix.instances.if == true
-  #       env:
-  #         SERVICE_ID: ${{ matrix.instances.serviceId }}
-  #         ENVIRONMENT_ID: ${{ matrix.instances.environmentId }}
-  #         CLOUD_PROVIDER: ${{ matrix.instances.cloudProvider }}
-  #         CLOUD_REGION: ${{ matrix.instances.cloudRegion }}
-  #         extraParams: ${{ matrix.instances.extraParams }}
-  #         SUBSCRIPTION_ID: ${{ matrix.instances.subscriptionId }}
-  #         REF_NAME: ${{ matrix.instances.tierName }}
-  #       run: |
-  #         export PATH="~/.local/bin:$PATH"
-  #         poetry run python -u ./omnistrate_tests/${{ matrix.instances.testFile }} ${{ secrets.OMNISTRATE_USERNAME }} ${{ secrets.OMNISTRATE_PASSWORD }} ${{ env.CLOUD_PROVIDER }} ${{ env.CLOUD_REGION }} --service-id ${{ env.SERVICE_ID }} --environment-id ${{ env.ENVIRONMENT_ID }} ${{ env.extraParams }}
+      - name: ${{ matrix.instances.name }}
+        if: matrix.instances.if == 'true' || matrix.instances.if == true
+        env:
+          SERVICE_ID: ${{ matrix.instances.serviceId }}
+          ENVIRONMENT_ID: ${{ matrix.instances.environmentId }}
+          CLOUD_PROVIDER: ${{ matrix.instances.cloudProvider }}
+          CLOUD_REGION: ${{ matrix.instances.cloudRegion }}
+          extraParams: ${{ matrix.instances.extraParams }}
+          SUBSCRIPTION_ID: ${{ matrix.instances.subscriptionId }}
+          REF_NAME: ${{ matrix.instances.tierName }}
+        run: |
+          export PATH="~/.local/bin:$PATH"
+          poetry run python -u ./omnistrate_tests/${{ matrix.instances.testFile }} ${{ secrets.OMNISTRATE_USERNAME }} ${{ secrets.OMNISTRATE_PASSWORD }} ${{ env.CLOUD_PROVIDER }} ${{ env.CLOUD_REGION }} --service-id ${{ env.SERVICE_ID }} --environment-id ${{ env.ENVIRONMENT_ID }} ${{ env.extraParams }}
 
-  # # Runs only if the branch is 'main' or 'v*'
-  # delete-networks:
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   if: contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main')
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  # Runs only if the branch is 'main' or 'v*'
+  delete-networks:
+    runs-on: ubuntu-latest
+    needs: test
+    if: contains(github.ref, 'refs/tags/v') || contains(github.ref, 'main')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  #     - name: Delete Omnistrate Custom Network - GCP
-  #       uses: ./.github/actions/delete-omnistrate-custom-network
-  #       continue-on-error: true
-  #       with:
-  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
-  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
-  #         custom_network_name: ${{ env.GCP_NETWORK_NAME }}
+      - name: Delete Omnistrate Custom Network - GCP
+        uses: ./.github/actions/delete-omnistrate-custom-network
+        continue-on-error: true
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          custom_network_name: ${{ env.GCP_NETWORK_NAME }}
 
-  #     - name: Delete Omnistrate Custom Network - AWS
-  #       continue-on-error: true
-  #       uses: ./.github/actions/delete-omnistrate-custom-network
-  #       with:
-  #         username: ${{ secrets.OMNISTRATE_USERNAME }}
-  #         password: ${{ secrets.OMNISTRATE_PASSWORD }}
-  #         custom_network_name: ${{ env.AWS_NETWORK_NAME }}
+      - name: Delete Omnistrate Custom Network - AWS
+        continue-on-error: true
+        uses: ./.github/actions/delete-omnistrate-custom-network
+        with:
+          username: ${{ secrets.OMNISTRATE_USERNAME }}
+          password: ${{ secrets.OMNISTRATE_PASSWORD }}
+          custom_network_name: ${{ env.AWS_NETWORK_NAME }}
 
   cleanup-runner:
-    #needs: test
+    needs: test
     if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:

--- a/omnistrate_tests/classes/falkordb_cluster.py
+++ b/omnistrate_tests/classes/falkordb_cluster.py
@@ -58,10 +58,11 @@ class FalkorDBClusterNode:
 
         return (
             int(self.hostname.split(".")[0].split("-")[-1])
-            if "-" in self.hostname and "." in self.hostname
+            if "-" in self.hostname and "." in self.hostname and "internal" not in self.hostname
+            else int(self.hostname.split(".")[0].split("-")[-2])
+            if "-" in self.hostname and "." in self.hostname and "internal" in self.hostname
             else None
         )
-
     @property
     def is_master(self) -> bool:
         return self.mode == "master"

--- a/omnistrate_tests/classes/omnistrate_fleet_instance.py
+++ b/omnistrate_tests/classes/omnistrate_fleet_instance.py
@@ -112,6 +112,7 @@ class OmnistrateFleetInstance:
         description: str,
         falkordb_user: str,
         falkordb_password: str,
+        network_type: str,
         product_tier_version: str | None = None,
         custom_network_id: str | None = None,
         **kwargs,
@@ -123,6 +124,7 @@ class OmnistrateFleetInstance:
         data = {
             "cloud_provider": deployment_cloud_provider,
             "region": deployment_region,
+            "network_type": network_type,
             "requestParams": {
                 "name": name,
                 "description": description,

--- a/omnistrate_tests/classes/omnistrate_fleet_instance.py
+++ b/omnistrate_tests/classes/omnistrate_fleet_instance.py
@@ -495,7 +495,7 @@ class OmnistrateFleetInstance:
 
         return endpoints
 
-    def get_cluster_endpoint(self):
+    def get_cluster_endpoint(self, network_type="PUBLIC"):
         resources = self.get_network_topology()
 
         resources_keys = resources.keys()
@@ -506,7 +506,7 @@ class OmnistrateFleetInstance:
                 and len(resources[key]["clusterEndpoint"]) > 0
                 and "streamer." not in resources[key]["clusterEndpoint"]
                 and "clusterPorts" in resources[key]
-                and resources[key]["networkingType"] != "INTERNAL"
+                and resources[key]["networkingType"] == network_type
             ):
                 return {
                     "endpoint": resources[key]["clusterEndpoint"],
@@ -514,13 +514,13 @@ class OmnistrateFleetInstance:
                 }
 
     def create_connection(
-        self, ssl: bool = False, force_reconnect: bool = False, retries=5
+        self, ssl: bool = False, force_reconnect: bool = False, retries=5, network_type="PUBLIC"
     ):
 
         if self._connection is not None and not force_reconnect:
             return self._connection
 
-        endpoint = self.get_cluster_endpoint()
+        endpoint = self.get_cluster_endpoint(network_type=network_type)
 
         # Connect to the master node
         while retries > 0:

--- a/omnistrate_tests/test_cluster.py
+++ b/omnistrate_tests/test_cluster.py
@@ -135,6 +135,7 @@ def test_cluster():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -148,7 +149,6 @@ def test_cluster():
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
             custom_network_id=network.network_id if network else None,
-            network_type=args.network_type,
 
         )
         

--- a/omnistrate_tests/test_cluster.py
+++ b/omnistrate_tests/test_cluster.py
@@ -56,6 +56,8 @@ parser.add_argument("--cluster-replicas", required=False, default="1")
 
 parser.add_argument("--ensure-mz-distribution", action="store_true")
 parser.add_argument("--custom-network", required=False)
+parser.add_argument("--network-type", required=False, default="PUBLIC")
+
 
 parser.add_argument(
     "--deployment-create-timeout-seconds", required=False, default=2600, type=int
@@ -146,6 +148,8 @@ def test_cluster():
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
             custom_network_id=network.network_id if network else None,
+            network_type=args.network_type,
+
         )
         
         try:

--- a/omnistrate_tests/test_cluster.py
+++ b/omnistrate_tests/test_cluster.py
@@ -154,7 +154,7 @@ def test_cluster():
         
         try:
             ip = resolve_hostname(instance=instance)
-            logging.info(f"Instance endpoint {instance.get_cluster_endpoint()['endpoint']} resolved to {ip}")
+            logging.info(f"Instance endpoint {instance.get_cluster_endpoint(network_type=args.network_type)['endpoint']} resolved to {ip}")
         except TimeoutError as e:
             logging.error(f"DNS resolution failed: {e}")
             raise Exception("Instance endpoint not ready: DNS resolution failed") from e
@@ -277,6 +277,7 @@ def test_failover(instance: OmnistrateFleetInstance):
     # Get instance host and port
     db = instance.create_connection(
         ssl=args.tls,
+        network_type=args.network_type,
     )
 
     graph = db.select_graph("test")
@@ -306,6 +307,7 @@ def test_stop_start(instance: OmnistrateFleetInstance):
     # Get instance host and port
     db = instance.create_connection(
         ssl=args.tls,
+        network_type=args.network_type,
     )
 
     graph = db.select_graph("test")
@@ -339,7 +341,7 @@ def test_zero_downtime(
 ):
     """This function should test the ability to read and write while a failover happens"""
     try:
-        db = instance.create_connection(ssl=ssl, force_reconnect=True)
+        db = instance.create_connection(ssl=ssl, force_reconnect=True, network_type=args.network_type)
 
         graph = db.select_graph("test")
         
@@ -371,7 +373,7 @@ def resolve_hostname(instance: OmnistrateFleetInstance,timeout=300, interval=1):
     if interval <= 0 or timeout <= 0:
         raise ValueError("Interval and timeout must be positive")
     
-    cluster_endpoint = instance.get_cluster_endpoint()
+    cluster_endpoint = instance.get_cluster_endpoint(network_type=args.network_type)
 
     if not cluster_endpoint or 'endpoint' not in cluster_endpoint:
         raise KeyError("Missing endpoint information in cluster configuration")

--- a/omnistrate_tests/test_cluster_replicas.py
+++ b/omnistrate_tests/test_cluster_replicas.py
@@ -54,7 +54,7 @@ parser.add_argument("--cluster-replicas", required=False, default="1")
 parser.add_argument("--shards", required=False, default="3")
 parser.add_argument("--persist-instance-on-fail",action="store_true")
 parser.add_argument("--ensure-mz-distribution", action="store_true")
-
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 parser.set_defaults(tls=False)
 args = parser.parse_args()
 
@@ -130,6 +130,7 @@ def test_cluster_replicas():
             AOFPersistenceConfig=args.aof_config,
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
+            network_type=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_cluster_replicas.py
+++ b/omnistrate_tests/test_cluster_replicas.py
@@ -118,6 +118,7 @@ def test_cluster_replicas():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -130,7 +131,6 @@ def test_cluster_replicas():
             AOFPersistenceConfig=args.aof_config,
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
-            network_type=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_cluster_shards.py
+++ b/omnistrate_tests/test_cluster_shards.py
@@ -51,6 +51,7 @@ parser.add_argument("--cluster-replicas", required=False, default="1")
 
 parser.add_argument("--ensure-mz-distribution", action="store_true")
 parser.add_argument("--persist-instance-on-fail",action="store_true")
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 
 parser.set_defaults(tls=False)
 args = parser.parse_args()
@@ -124,6 +125,7 @@ def test_cluster_shards():
             AOFPersistenceConfig=args.aof_config,
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
+            network_type=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_cluster_shards.py
+++ b/omnistrate_tests/test_cluster_shards.py
@@ -113,6 +113,7 @@ def test_cluster_shards():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -125,7 +126,6 @@ def test_cluster_shards():
             AOFPersistenceConfig=args.aof_config,
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
-            network_type=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_replication.py
+++ b/omnistrate_tests/test_replication.py
@@ -64,6 +64,7 @@ parser.add_argument("--rdb-config", required=False, default="medium")
 parser.add_argument("--aof-config", required=False, default="always")
 parser.add_argument("--persist-instance-on-fail",action="store_true")
 parser.add_argument("--custom-network", required=False)
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 
 parser.set_defaults(tls=False)
 args = parser.parse_args()
@@ -137,6 +138,7 @@ def test_replication():
             RDBPersistenceConfig=args.rdb_config,
             AOFPersistenceConfig=args.aof_config,
             custom_network_id=network.network_id if network else None,
+            network_type=args.network_type,
         )
         
         try:

--- a/omnistrate_tests/test_replication.py
+++ b/omnistrate_tests/test_replication.py
@@ -143,7 +143,7 @@ def test_replication():
         
         try:
             ip = resolve_hostname(instance=instance)
-            logging.info(f"Instance endpoint {instance.get_cluster_endpoint()['endpoint']} resolved to {ip}")
+            logging.info(f"Instance endpoint {instance.get_cluster_endpoint(network_type=args.network_type)['endpoint']} resolved to {ip}")
         except TimeoutError as e:
             logging.error(f"DNS resolution failed: {e}")
             raise Exception("Instance endpoint not ready: DNS resolution failed") from e
@@ -453,7 +453,7 @@ def test_zero_downtime(
 ):
     """This function should test the ability to read and write while replication happens"""
     try:
-        db = instance.create_connection(ssl=ssl, force_reconnect=True)
+        db = instance.create_connection(ssl=ssl, force_reconnect=True, network_type=args.network_type)
 
         graph = db.select_graph("test")
 
@@ -485,7 +485,7 @@ def resolve_hostname(instance: OmnistrateFleetInstance,timeout=300, interval=1):
     if interval <= 0 or timeout <= 0:
         raise ValueError("Interval and timeout must be positive")
     
-    cluster_endpoint = instance.get_cluster_endpoint()
+    cluster_endpoint = instance.get_cluster_endpoint(network_type=args.network_type)
 
     if not cluster_endpoint or 'endpoint' not in cluster_endpoint:
         raise KeyError("Missing endpoint information in cluster configuration")

--- a/omnistrate_tests/test_replication.py
+++ b/omnistrate_tests/test_replication.py
@@ -127,6 +127,7 @@ def test_replication():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -138,7 +139,6 @@ def test_replication():
             RDBPersistenceConfig=args.rdb_config,
             AOFPersistenceConfig=args.aof_config,
             custom_network_id=network.network_id if network else None,
-            network_type=args.network_type,
         )
         
         try:

--- a/omnistrate_tests/test_replication_replicas.py
+++ b/omnistrate_tests/test_replication_replicas.py
@@ -111,6 +111,7 @@ def test_add_remove_replica():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -121,7 +122,6 @@ def test_add_remove_replica():
             enableTLS=args.tls,
             RDBPersistenceConfig=args.rdb_config,
             AOFPersistenceConfig=args.aof_config,
-            networkType=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_replication_replicas.py
+++ b/omnistrate_tests/test_replication_replicas.py
@@ -51,7 +51,7 @@ parser.add_argument("--rdb-config", required=False, default="medium")
 parser.add_argument("--aof-config", required=False, default="always")
 parser.add_argument("--replica-count", required=False, default="2")
 parser.add_argument("--persist-instance-on-fail", action="store_true")
-
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 parser.set_defaults(tls=False)
 args = parser.parse_args()
 
@@ -121,6 +121,7 @@ def test_add_remove_replica():
             enableTLS=args.tls,
             RDBPersistenceConfig=args.rdb_config,
             AOFPersistenceConfig=args.aof_config,
+            networkType=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_standalone.py
+++ b/omnistrate_tests/test_standalone.py
@@ -49,6 +49,7 @@ parser.add_argument("--rdb-config", required=False, default="medium")
 parser.add_argument("--aof-config", required=False, default="always")
 parser.add_argument("--persist-instance-on-fail",action="store_true")
 parser.add_argument("--custom-network", required=False)
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 
 parser.set_defaults(tls=False)
 args = parser.parse_args()
@@ -123,6 +124,7 @@ def test_standalone():
             RDBPersistenceConfig=args.rdb_config,
             AOFPersistenceConfig=args.aof_config,
             custom_network_id=network.network_id if network else None,
+            network_type=args.network_type,
         )
         
         try:

--- a/omnistrate_tests/test_standalone.py
+++ b/omnistrate_tests/test_standalone.py
@@ -113,6 +113,7 @@ def test_standalone():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -124,7 +125,6 @@ def test_standalone():
             RDBPersistenceConfig=args.rdb_config,
             AOFPersistenceConfig=args.aof_config,
             custom_network_id=network.network_id if network else None,
-            network_type=args.network_type,
         )
         
         try:

--- a/omnistrate_tests/test_update_memory.py
+++ b/omnistrate_tests/test_update_memory.py
@@ -123,6 +123,7 @@ def test_update_memory():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -135,7 +136,6 @@ def test_update_memory():
             AOFPersistenceConfig=args.aof_config,
             clusterReplicas=args.cluster_replicas,
             hostCount=args.host_count,
-            network_type=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_update_memory.py
+++ b/omnistrate_tests/test_update_memory.py
@@ -53,7 +53,7 @@ parser.add_argument("--aof-config", required=False, default="always")
 parser.add_argument("--cluster-replicas", required=False, default="1")
 parser.add_argument("--host-count", required=False, default="6")
 parser.add_argument("--persist-instance-on-fail",action="store_true")
-
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 parser.set_defaults(tls=False)
 args = parser.parse_args()
 
@@ -123,6 +123,7 @@ def test_update_memory():
             AOFPersistenceConfig=args.aof_config,
             clusterReplicas=args.cluster_replicas,
             hostCount=args.host_count,
+            network_type=args.network_type,
         )
 
         try:

--- a/omnistrate_tests/test_upgrade_version.py
+++ b/omnistrate_tests/test_upgrade_version.py
@@ -143,6 +143,7 @@ def test_upgrade_version():
         instance.create(
             wait_for_ready=True,
             deployment_cloud_provider=args.cloud_provider,
+            network_type=args.network_type,
             deployment_region=args.region,
             name=args.instance_name,
             description=args.instance_description,
@@ -156,7 +157,7 @@ def test_upgrade_version():
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
             product_tier_version=last_tier.version,
-            network_type=args.network_type,
+
         )
 
         try:

--- a/omnistrate_tests/test_upgrade_version.py
+++ b/omnistrate_tests/test_upgrade_version.py
@@ -55,7 +55,7 @@ parser.add_argument("--aof-config", required=False, default="always")
 parser.add_argument("--host-count", required=False, default="6")
 parser.add_argument("--cluster-replicas", required=False, default="1")
 parser.add_argument("--persist-instance-on-fail", action="store_true")
-
+parser.add_argument("--network-type", required=False, default="PUBLIC")
 parser.set_defaults(tls=False)
 args = parser.parse_args()
 
@@ -156,6 +156,7 @@ def test_upgrade_version():
             hostCount=args.host_count,
             clusterReplicas=args.cluster_replicas,
             product_tier_version=last_tier.version,
+            network_type=args.network_type,
         )
 
         try:


### PR DESCRIPTION
### **User description**
fix #159


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Added support for `network_type` in instance creation and tests.

- Enhanced test scripts to handle private/internal network configurations.

- Introduced GCP-specific private runners and cleanup workflows.

- Updated GitHub Actions to support private network testing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>falkordb_cluster.py</strong><dd><code>Adjusted `idx` property to handle internal hostnames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-85e9fe10abd36a7479241e28303c43a8d9b3c190daa07bfa3d8ee5ad9be16fa7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>omnistrate_fleet_instance.py</strong><dd><code>Added `network_type` support for instance creation and connection</code></dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-a2e0286c23b781c0b885e431c6fe15ccdc394e41eb951b761e1a826bcc96062f">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action.yml</strong><dd><code>Added action for cleaning up GCP runners</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-0ddff494ff604459e97ef2dc492dcbf46e431810ac2a4071e4f76fbe0b9ab3e2">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>test_cluster.py</strong><dd><code>Added `network_type` argument to cluster tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-51d67321769f7202be233c366423cbbce4538d2d2bd02a8fdf2c35f24f4fc5eb">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_cluster_replicas.py</strong><dd><code>Added `network_type` argument to cluster replica tests</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-2efa737523abf1af99f658b84375aeb11bde262d889f5f34d085f748306b4695">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_cluster_shards.py</strong><dd><code>Added `network_type` argument to cluster shard tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-30e534bfff310a0fda3bf2c9b998aa0b04307272def2e49ec0453bc65edad3bc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_replication.py</strong><dd><code>Added `network_type` argument to replication tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-5a1249bb76848a722a7a5855da2c7b1025ef8113dae6310d0efb40e486c8f23a">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_replication_replicas.py</strong><dd><code>Added `network_type` argument to replication replica tests</code></dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-d7b7d40d290f83c1788c17d8eab05c300d050d460826e69897a0346f274af3d1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_standalone.py</strong><dd><code>Added `network_type` argument to standalone tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-7f9aefa9d13e9e8d85d11d2f0a1080de06cdb6efe1180d7324150a63f211ab64">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_update_memory.py</strong><dd><code>Added `network_type` argument to memory update tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-0d01d4d858ccaeb5e270b1b8521764b506b2de5e0ea77c76e5cf7eca005c2a5a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_upgrade_version.py</strong><dd><code>Added `network_type` argument to version upgrade tests</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-70bf0d2fe9d1f34213c583235fa51be7e7990c8c182158ca9a55a8e4e35760d9">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>build-test-image.yaml</strong><dd><code>Updated workflows to include private network runners and cleanup</code></dd></td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/221/files#diff-85593cb19f51ef12870386e47f306f5fafb696776b67a61351f81a0583aa7427">+80/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for specifying network type (PUBLIC/INTERNAL) in test scripts and instance creation.
  - Introduced a new GitHub Action for cleaning up GCP spot instances.

- **Infrastructure**
  - Enhanced GitHub Actions workflow to dynamically create and manage GCP runners.
  - Updated test infrastructure to support flexible network configurations.

- **Testing**
  - Improved test scripts with new network type configuration option.
  - Added more robust runner management and cleanup processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->