### PR TITLE
changed instance size

### DIFF
--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -476,26 +476,26 @@ jobs:
           #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
           #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
           #   extraParams: "--resource-key 'cluster-Multi-Zone' --instance-name 'test-cluster-mz-replicas' --instance-description 'test-cluster-mz-replicas' --instance-type 'e2-custom-4-8192' --storage-size '30' --rdb-config 'medium' --aof-config 'always' --host-count '6' --cluster-replicas '1' --shards '3' --ensure-mz-distribution"
-          - name: PRO/SingleZone - GCP/us-central1 - Test add/remove replica
-            if: "true"
-            testFile: test_replication_replicas.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
-          - name: PRO/MultiZone - GCP/us-central1 - Test add/remove replica
-            if: "true"
-            testFile: test_replication_replicas.py
-            tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-            cloudProvider: gcp
-            cloudRegion: us-central1
-            subscriptionId: sub-GJPV3NoNC0
-            serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
-            environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
-            extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          # - name: PRO/SingleZone - GCP/us-central1 - Test add/remove replica
+          #   if: "true"
+          #   testFile: test_replication_replicas.py
+          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          #   cloudProvider: gcp
+          #   cloudRegion: us-central1
+          #   subscriptionId: sub-GJPV3NoNC0
+          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+          #   extraParams: "--resource-key 'single-Zone' --replica-id 'node-sz-0' --instance-name 'test-sz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
+          # - name: PRO/MultiZone - GCP/us-central1 - Test add/remove replica
+          #   if: "true"
+          #   testFile: test_replication_replicas.py
+          #   tierName: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          #   cloudProvider: gcp
+          #   cloudRegion: us-central1
+          #   subscriptionId: sub-GJPV3NoNC0
+          #   serviceId: ${{ vars.OMNISTRATE_INTERNAL_SERVICE_ID }}
+          #   environmentId: ${{ vars.OMNISTRATE_INTERNAL_DEV_ENVIRONMENT}}
+          #   extraParams: "--resource-key 'multi-Zone' --replica-id 'node-mz-0'  --instance-name 'test-mz-add-remove-replica' --instance-description 'test-replication-add-remove' --instance-type 'e2-medium' --storage-size '30' --rdb-config 'medium' --aof-config 'always'"
             ###################### GCP private ######################
           - name: PRO/ClusterMultiZone - PRIVATE/GCP/us-central1 - Failover & Persistence
             if: "true"

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         machines:
           - name: replication-runner-private-gcp
-            machine_type: e2-standard-4
+            machine_type: e2-medium
             runner_label: replication-${{ github.run_id }}-${{ github.run_number }}
             arm: false
             image: projects/app-plane-dev-f7a2434f/global/images/gh-runner-debian
           - name: cluster-runner-private-gcp
-            machine_type: e2-standard-4
+            machine_type: e2-medium
             runner_label: cluster-${{ github.run_id }}-${{ github.run_number }}
             arm: false
             image: projects/app-plane-dev-f7a2434f/global/images/gh-runner-debian

--- a/falkordb-cluster/cluster-entrypoint.sh
+++ b/falkordb-cluster/cluster-entrypoint.sh
@@ -56,6 +56,7 @@ IS_MULTI_ZONE=${IS_MULTI_ZONE:-0}
 
 NODE_HOST=${NODE_HOST:-localhost}
 NODE_PORT=${NODE_PORT:-6379}
+BUS_PORT=${BUS_PORT:-16379}
 
 ROOT_CA_PATH=${ROOT_CA_PATH:-/etc/ssl/certs/GlobalSign_Root_CA.pem}
 TLS_MOUNT_PATH=${TLS_MOUNT_PATH:-/etc/tls}
@@ -202,7 +203,7 @@ update_ips_in_nodes_conf(){
     echo "The new ip is: $POD_IP"
     echo "The port is: $NODE_PORT"
 
-    sed -i "s/$res/$POD_IP:$NODE_PORT@1$NODE_PORT/" $DATA_DIR/nodes.conf
+    sed -i "s/$res/$POD_IP:$NODE_PORT@$BUS_PORT/" $DATA_DIR/nodes.conf
     cat $DATA_DIR/nodes.conf
     
   else

--- a/omnistrate.enterprise.yaml
+++ b/omnistrate.enterprise.yaml
@@ -714,7 +714,7 @@ services:
         description: Number of Replicas
         name: Number of Replicas
         type: Float64
-        modifiable: true
+        modifiable: false
         required: false
         export: true
         defaultValue: "2"
@@ -1217,7 +1217,7 @@ services:
         description: Number of Replicas
         name: Number of Replicas
         type: Float64
-        modifiable: true
+        modifiable: false
         required: false
         export: true
         defaultValue: "2"

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -711,7 +711,7 @@ services:
         description: Number of Replicas
         name: Number of Replicas
         type: Float64
-        modifiable: true
+        modifiable: false
         required: false
         export: true
         defaultValue: "2"
@@ -1258,7 +1258,7 @@ services:
         description: Number of Replicas
         name: Number of Replicas
         type: Float64
-        modifiable: true
+        modifiable: false
         required: false
         export: true
         defaultValue: "2"

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -717,7 +717,6 @@ services:
         defaultValue: "2"
         options:
           - "2"
-          - "3"
         parameterDependencyMap:
           node-sz: numReplicas
       - key: enableTLS
@@ -1264,7 +1263,6 @@ services:
         defaultValue: "2"
         options:
           - "2"
-          - "3"
         parameterDependencyMap:
           node-mz: numReplicas
       - key: enableTLS

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -905,7 +905,6 @@ services:
         defaultValue: "2"
         options:
           - "2"
-          - "3"
       - key: enableTLS
         description: Whether to enable TLS for the database
         name: Enable TLS
@@ -1451,7 +1450,6 @@ services:
         defaultValue: "2"
         options:
           - "2"
-          - "3"
       - key: enableTLS
         description: Whether to enable TLS for the database
         name: Enable TLS


### PR DESCRIPTION
fix #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Infrastructure**
	- Updated GitHub Actions workflow runner machine types from `e2-standard-4` to `e2-medium`.
- **New Features**
	- Introduced a new environment variable `BUS_PORT` with a default value of `16379` for node configuration updates.
- **Configuration Changes**
	- Set `numReplicas` parameter to `modifiable: false` in both `Single-Zone` and `Multi-Zone` service configurations for `omnistrate.enterprise.yaml` and `omnistrate.pro.yaml`.
	- Removed the option "3" for `numReplicas`, leaving only "2" as the available option in `omnistrate.pro.yaml`.
	- Commented out specific test cases related to replica functionality in the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->