### PR TITLE
Healthcheck waits for data to load

### DIFF
--- a/healthcheck_rs/src/main.rs
+++ b/healthcheck_rs/src/main.rs
@@ -174,7 +174,10 @@ fn get_status_from_cluster_node(
 /// # Returns
 /// 
 /// A boolean value that indicates whether the Redis master is ready
-fn get_status_from_master(_db_info: &str) -> Result<bool, redis::RedisError> {
+fn get_status_from_master(db_info: &str) -> Result<bool, redis::RedisError> {
+    if db_info.contains("loading:1") {
+        return Ok(false);
+    }
     Ok(true)
 }
 
@@ -191,6 +194,10 @@ fn get_status_from_master(_db_info: &str) -> Result<bool, redis::RedisError> {
 /// 
 /// A boolean value that indicates whether the Redis slave is ready
 fn get_status_from_slave(db_info: &str) -> Result<bool, redis::RedisError> {
+    if db_info.contains("loading:1") {
+        return Ok(false);
+    }
+    
     if !db_info.contains("master_link_status:up") || db_info.contains("master_sync_in_progress:1") {
         return Ok(false);
     }

--- a/healthcheck_rs/src/main.rs
+++ b/healthcheck_rs/src/main.rs
@@ -38,7 +38,7 @@ fn start_health_check_server(is_sentinel: bool) {
     let server = Server::new(addr, move |request| {
         router!(request,
             (GET) (/healthcheck) => {
-                let health = health_check_handler(is_sentinel).unwrap();
+                let health = health_check_handler(is_sentinel).unwrap_or_else(|_| false);
 
                 if health {
                     Response::text("OK")


### PR DESCRIPTION
### **User description**
fix #233


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated health check to verify data loading status.

- Modified `get_status_from_master` to handle `loading:1` condition.

- Enhanced `get_status_from_slave` to check for data loading.

- Improved error handling in health check server response.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Enhanced health check logic for data readiness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

healthcheck_rs/src/main.rs

<li>Updated <code>health_check_handler</code> to handle errors gracefully.<br> <li> Added logic in <code>get_status_from_master</code> to check for <code>loading:1</code>.<br> <li> Enhanced <code>get_status_from_slave</code> to verify data loading and master link <br>status.<br> <li> Improved startup probe reliability by ensuring data readiness.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/234/files#diff-b9e752dc423056f85fe3be1114acdb20922da680218be5aa3786cefaee5c6612">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved error handling in health check server
    - Added checks to prevent reporting Redis instances as ready when they are still loading
- **Enhancements**
    - Enhanced robustness of health check logic for Redis instances
    - Implemented more precise status determination for master and slave nodes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->