### PR TITLE
updated requests to 100m

### DIFF
--- a/omnistrate.free.yaml
+++ b/omnistrate.free.yaml
@@ -165,7 +165,7 @@ services:
       resources:
         limits:
           cpus: "0.5"
-          memory: 200M
+          memory: 100M
         reservations:
           cpus: "0.1"
           memory: 200M

--- a/omnistrate.free.yaml
+++ b/omnistrate.free.yaml
@@ -165,10 +165,10 @@ services:
       resources:
         limits:
           cpus: "0.5"
-          memory: 100M
+          memory: 200M
         reservations:
           cpus: "0.1"
-          memory: 200M
+          memory: 100M
     x-omnistrate-actionhooks:
       - scope: NODE
         type: HEALTH_CHECK


### PR DESCRIPTION
### **User description**
fix #235


___

### **PR Type**
Enhancement


___

### **Description**
- Updated memory allocation for free tier instances.

- Changed memory request to 100MB and limit to 200MB.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>omnistrate.free.yaml</strong><dd><code>Adjust memory allocation for free tier instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

omnistrate.free.yaml

<li>Updated memory request to 100MB.<br> <li> Ensured memory limit remains at 200MB.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/236/files#diff-74984abd7311206ec876558089f4dcff03db9b3ba768747a9d246df19d107f20">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Reduced memory allocation for the `node-f` service from 200MB to 100MB
	- Optimized resource configuration for more efficient deployment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->