### PR TITLE
remove startup tier when pr is closed

### DIFF
--- a/.github/workflows/delete-omnistrate-service-plan.yaml
+++ b/.github/workflows/delete-omnistrate-service-plan.yaml
@@ -47,6 +47,7 @@ jobs:
           - tier-name: free-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           - tier-name: pro-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           - tier-name: enterprise-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          - tier-name: startup-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### **User description**
fix #250


___

### **PR Type**
Enhancement


___

### **Description**
- Added deletion of `startup` tier in GitHub Actions workflow.

- Ensures `startup` tier is removed when PR is closed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>delete-omnistrate-service-plan.yaml</strong><dd><code>Include `startup` tier in service plan deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/delete-omnistrate-service-plan.yaml

<li>Added <code>startup</code> tier to the matrix of plans.<br> <li> Ensures <code>startup</code> tier is handled similarly to other tiers.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-omnistrate/pull/251/files#diff-94133978a4983ac7f728ca3488d6f96efb76bfde2e971ef8b8640c1c00db0660">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the automated service plan deletion process by supporting an additional startup tier. This update allows tier-specific handling based on branch or pull request context, improving flexibility in managing service plan deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->