### PR TITLE
change redis_exporter to falkordb/redis_exporter

### DIFF
--- a/falkordb-cluster/Dockerfile
+++ b/falkordb-cluster/Dockerfile
@@ -1,6 +1,6 @@
 ARG FALKORDB_VERSION=v4.4.1
 
-FROM oliver006/redis_exporter:alpine as redis_exporter
+FROM falkordb/redis_exporter:v1.68.0-alpine as redis_exporter
 
 
 FROM rust:1-slim-buster as healthcheck_builder

--- a/falkordb-node/Dockerfile
+++ b/falkordb-node/Dockerfile
@@ -1,6 +1,6 @@
 ARG FALKORDB_VERSION=v4.4.1
 
-FROM oliver006/redis_exporter:alpine as redis_exporter
+FROM falkordb/redis_exporter:v1.68.0-alpine as redis_exporter
 
 
 FROM rust:1-slim-buster as healthcheck_builder

--- a/omnistrate.enterprise.yaml
+++ b/omnistrate.enterprise.yaml
@@ -42,6 +42,9 @@ x-internal-integrations:
 x-falkordbMetrics: &metrics
   prometheusEndpoint: "http://localhost:9121/metrics"
   metrics:
+    redis_aof_file_size_bytes:
+      "AOF File Size (Bytes)":
+        aggregationFunction: sum
     redis_commands_latencies_usec_bucket:
       "Command Latency (μs) Bucket":
         aggregationFunction: sum

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -40,6 +40,9 @@ x-internal-integrations:
 x-falkordbMetrics: &metrics
   prometheusEndpoint: "http://localhost:9121/metrics"
   metrics:
+    redis_aof_file_size_bytes:
+      "AOF File Size (Bytes)":
+        aggregationFunction: sum
     redis_commands_latencies_usec_bucket:
       "Command Latency (μs) Bucket":
         aggregationFunction: sum

--- a/omnistrate.startup.yaml
+++ b/omnistrate.startup.yaml
@@ -20,6 +20,9 @@ x-internal-integrations:
 x-falkordbMetrics: &metrics
   prometheusEndpoint: "http://localhost:9121/metrics"
   metrics:
+    redis_aof_file_size_bytes:
+      "AOF File Size (Bytes)":
+        aggregationFunction: sum
     redis_commands_latencies_usec_bucket:
       "Command Latency (μs) Bucket":
         aggregationFunction: sum


### PR DESCRIPTION
and export aof metric

fix #254 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new monitoring metric to track the size of the Append Only File in bytes, offering enhanced insight into data persistence.

- **Chores**
  - Updated container configurations to use a newer Redis exporter image.
  - Improved startup script formatting for better internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->