### PR TITLE
add aof to redis_exporter on node

### DIFF
--- a/falkordb-cluster/cluster-entrypoint.sh
+++ b/falkordb-cluster/cluster-entrypoint.sh
@@ -477,7 +477,7 @@ if [[ $RUN_METRICS -eq 1 ]]; then
   echo "Starting Metrics"
   aof_metric_export=$(if [[ $PERSISTENCE_AOF_CONFIG != "no" ]]; then echo "-include-aof-file-size"; else echo ""; fi)
   exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://$NODE_HOST:$NODE_PORT"; else echo "redis://localhost:$NODE_PORT"; fi)
-  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -is-cluster -tls-server-min-version TLS1.3 $aof_metric_export >>$FALKORDB_LOG_FILE_PATH &
+  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -is-cluster -tls-server-min-version TLS1.3 -include-system-metrics $aof_metric_export >>$FALKORDB_LOG_FILE_PATH &
   redis_exporter_pid=$!
 fi
 

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -556,8 +556,9 @@ fi
 
 if [[ $RUN_METRICS -eq 1 ]]; then
   echo "Starting Metrics"
+  aof_metric_export=$(if [[ $PERSISTENCE_AOF_CONFIG != "no" ]]; then echo "-include-aof-file-size"; else echo ""; fi)
   exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://$NODE_HOST:$NODE_PORT"; else echo "redis://localhost:$NODE_PORT"; fi)
-  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -tls-server-min-version TLS1.3 &
+  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -tls-server-min-version TLS1.3 -include-system-metrics $aof_metric_export &
   redis_exporter_pid=$!
 fi
 


### PR DESCRIPTION
add -include-system-metrics

fix #254 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The Redis exporter now collects system metrics to provide broader insight into system performance.
	- An optional configuration enables reporting on additional metrics related to AOF file sizes for enhanced analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->