### PR TITLE
fix: update exporter URL to use localhost for TLS connections

### DIFF
--- a/falkordb-cluster/cluster-entrypoint.sh
+++ b/falkordb-cluster/cluster-entrypoint.sh
@@ -475,7 +475,7 @@ fi
 if [[ $RUN_METRICS -eq 1 ]]; then
   echo "Starting Metrics"
   aof_metric_export=$(if [[ $PERSISTENCE_AOF_CONFIG != "no" ]]; then echo "-include-aof-file-size"; else echo ""; fi)
-  exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://$NODE_HOST:$NODE_PORT"; else echo "redis://localhost:$NODE_PORT"; fi)
+  exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://localhost:$NODE_PORT"; else echo "redis://localhost:$NODE_PORT"; fi)
   redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -is-cluster -tls-server-min-version TLS1.3 -include-system-metrics $aof_metric_export >>$FALKORDB_LOG_FILE_PATH &
   redis_exporter_pid=$!
 fi

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -585,7 +585,7 @@ if [[ $RUN_METRICS -eq 1 ]]; then
   aof_metric_export=$(if [[ $PERSISTENCE_AOF_CONFIG != "no" ]]; then echo "-include-aof-file-size"; else echo ""; fi)
   # When TLS is enabled, use RANDOM_NODE_PORT to get the external port if defined (multi tenancy tiers)
   node_external_port=$(if [[ $TLS == "true" && -z $RANDOM_NODE_PORT ]]; then echo $NODE_PORT; else echo $RANDOM_NODE_PORT; fi)
-  exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://$NODE_HOST:$node_external_port"; else echo "redis://localhost:$NODE_PORT"; fi)
+  exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://localhost:$node_external_port"; else echo "redis://localhost:$NODE_PORT"; fi)
   redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -tls-server-min-version TLS1.3 -include-system-metrics $aof_metric_export &
   redis_exporter_pid=$!
 fi


### PR DESCRIPTION
fix #274 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced secure metrics reporting by standardizing the connection behavior in both cluster and node operations. With TLS enabled, metrics now consistently connect via the local host, ensuring more reliable and stable monitoring without affecting non-secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->