### PR TITLE
add extra .1 G for startup tier

### DIFF
--- a/omnistrate.startup.yaml
+++ b/omnistrate.startup.yaml
@@ -283,8 +283,8 @@ services:
         export: true
         defaultValue: "1GB"
         labeledOptions:
-          1GB: "1G"
-          2GB: "2G"
+          1GB: "1.1G"
+          2GB: "2.1G"
         parameterDependencyMap:
           node-s: memoryRequestsAndLimits
     x-omnistrate-capabilities:
@@ -429,8 +429,8 @@ services:
         export: true
         defaultValue: "1GB"
         labeledOptions:
-          1GB: "1G"
-          2GB: "2G"
+          1GB: "1.1G"
+          2GB: "2.1G"
       - key: resourceRequestCPU
         name: CPU Request
         description: CPU Request for the Falkordb instance


### PR DESCRIPTION
fix #285 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised memory configuration options for select services by updating the available memory thresholds from previous values to new ones (1.1G and 2.1G), ensuring a refreshed presentation for memory selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->