### PR TITLE
bump FALKORDB_VERSION to v4.8.6 in build workflows

### DIFF
--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -15,7 +15,7 @@ concurrency:
 env:
   NODE_IMAGE_NAME: falkordb-node
   CLUSTER_IMAGE_NAME: falkordb-cluster
-  FALKORDB_VERSION: v4.8.4
+  FALKORDB_VERSION: v4.8.6
   CLUSTER_REBALANCE_IMAGE_NAME: falkordb-cluster-rebalance
 
 jobs:

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -16,7 +16,7 @@ env:
   NODE_IMAGE_NAME: falkordb-node
   CLUSTER_IMAGE_NAME: falkordb-cluster
   CLUSTER_REBALANCE_IMAGE_NAME: falkordb-cluster-rebalance
-  FALKORDB_VERSION: v4.8.4
+  FALKORDB_VERSION: v4.8.6
   FREE_PLAN_NAME: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
   PRO_PLAN_NAME: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
   ENTERPRISE_PLAN_NAME: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}

--- a/falkordb-cluster/Dockerfile
+++ b/falkordb-cluster/Dockerfile
@@ -1,4 +1,4 @@
-ARG FALKORDB_VERSION=v4.8.4
+ARG FALKORDB_VERSION=v4.8.6
 
 FROM falkordb/redis_exporter:v1.68.0-alpine as redis_exporter
 

--- a/falkordb-node/Dockerfile
+++ b/falkordb-node/Dockerfile
@@ -1,4 +1,4 @@
-ARG FALKORDB_VERSION=v4.8.4
+ARG FALKORDB_VERSION=v4.8.6
 
 FROM falkordb/redis_exporter:v1.68.0-alpine as redis_exporter
 


### PR DESCRIPTION
fix #292 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the underlying database version to v4.8.6 for build and test processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->