### PR TITLE
feat: enhance metrics handling for Redis and Sentinel

### DIFF
--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -606,7 +606,7 @@ if [[ $RUN_METRICS -eq 1 && $RUN_SENTINEL -eq 1 ]]; then
   echo "Starting Metrics for Sentinel"
   # When TLS is enabled, use RANDOM_NODE_PORT to get the external port if defined (multi tenancy tiers)
   exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://localhost:$SENTINEL_PORT"; else echo "redis://localhost:$SENTINEL_PORT"; fi)
-  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -tls-server-min-version TLS1.3 &
+  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -web.listen-address '0.0.0.0:9122'  -log-format json -tls-server-min-version TLS1.3 &
   redis_exporter_sentinel_pid=$!
 fi
 

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -185,6 +185,10 @@ handle_sigterm() {
   if [[ $RUN_METRICS -eq 1 && ! -z $redis_exporter_pid ]]; then
     kill -TERM $redis_exporter_pid
   fi
+  
+  if [[ $RUN_METRICS -eq 1 && ! -z $redis_exporter_sentinel_pid ]]; then
+    kill -TERM $redis_exporter_sentinel_pid
+  fi
 
   if [[ $RUN_HEALTH_CHECK -eq 1 && ! -z $healthcheck_pid ]]; then
     kill -TERM $healthcheck_pid
@@ -590,12 +594,20 @@ else
 fi
 
 if [[ $RUN_METRICS -eq 1 ]]; then
-  echo "Starting Metrics"
+  echo "Starting Metrics for Redis"
   aof_metric_export=$(if [[ $PERSISTENCE_AOF_CONFIG != "no" ]]; then echo "-include-aof-file-size"; else echo ""; fi)
   # When TLS is enabled, use RANDOM_NODE_PORT to get the external port if defined (multi tenancy tiers)
   exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://localhost:$NODE_PORT"; else echo "redis://localhost:$NODE_PORT"; fi)
   redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -tls-server-min-version TLS1.3 -include-system-metrics -is-falkordb -slowlog-history-enabled $aof_metric_export &
   redis_exporter_pid=$!
+fi
+
+if [[ $RUN_METRICS -eq 1 && $RUN_SENTINEL -eq 1 ]]; then
+  echo "Starting Metrics for Sentinel"
+  # When TLS is enabled, use RANDOM_NODE_PORT to get the external port if defined (multi tenancy tiers)
+  exporter_url=$(if [[ $TLS == "true" ]]; then echo "rediss://localhost:$SENTINEL_PORT"; else echo "redis://localhost:$SENTINEL_PORT"; fi)
+  redis_exporter -skip-tls-verification -redis.password $ADMIN_PASSWORD -redis.addr $exporter_url -log-format json -tls-server-min-version TLS1.3 &
+  redis_exporter_sentinel_pid=$!
 fi
 
 #Start cron

--- a/omnistrate.enterprise.byoa.yaml
+++ b/omnistrate.enterprise.byoa.yaml
@@ -1298,7 +1298,7 @@ services:
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
-      - RUN_METRICS=0
+      - RUN_METRICS=1
       - RUN_HEALTH_CHECK_SENTINEL=1
       - DEBUG=0
       - SENTINEL_PORT=26379
@@ -1960,7 +1960,7 @@ services:
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
-      - RUN_METRICS=0
+      - RUN_METRICS=1
       - RUN_HEALTH_CHECK_SENTINEL=1
       - DEBUG=0
       - SENTINEL_PORT=26379

--- a/omnistrate.enterprise.yaml
+++ b/omnistrate.enterprise.yaml
@@ -1307,7 +1307,7 @@ services:
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
-      - RUN_METRICS=0
+      - RUN_METRICS=1
       - RUN_HEALTH_CHECK_SENTINEL=1
       - DEBUG=0
       - SENTINEL_PORT=26379
@@ -1969,7 +1969,7 @@ services:
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
-      - RUN_METRICS=0
+      - RUN_METRICS=1
       - RUN_HEALTH_CHECK_SENTINEL=1
       - DEBUG=0
       - SENTINEL_PORT=26379

--- a/omnistrate.pro.yaml
+++ b/omnistrate.pro.yaml
@@ -1312,7 +1312,7 @@ services:
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
-      - RUN_METRICS=0
+      - RUN_METRICS=1
       - RUN_HEALTH_CHECK_SENTINEL=1
       - DEBUG=0
       - REDIS_EXPORTER_DEBUG=false
@@ -1976,7 +1976,7 @@ services:
     environment:
       - RUN_NODE=0
       - RUN_SENTINEL=1
-      - RUN_METRICS=0
+      - RUN_METRICS=1
       - RUN_HEALTH_CHECK_SENTINEL=1
       - DEBUG=0
       - REDIS_EXPORTER_DEBUG=false


### PR DESCRIPTION
fix #344 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate metrics collection for the Sentinel service when both metrics and Sentinel are enabled.
  * Enabled metrics collection by default for Sentinel services in single-zone and multi-zone configurations.
* **Bug Fixes**
  * Ensured proper shutdown of the Sentinel metrics exporter process alongside the main Redis exporter during termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->