### PR TITLE
Update .SO path for old instances

### DIFF
--- a/falkordb-cluster/cluster-entrypoint.sh
+++ b/falkordb-cluster/cluster-entrypoint.sh
@@ -425,6 +425,8 @@ join_cluster() {
 
 run_node() {
 
+  # Update .SO path for old instances
+  sed -i "s|/FalkorDB/bin/src/falkordb.so|/var/lib/falkordb/bin/falkordb.so|g" $NODE_CONF_FILE
   sed -i "s/\$ADMIN_PASSWORD/$ADMIN_PASSWORD/g" $NODE_CONF_FILE
   sed -i "s/\$LOG_LEVEL/$LOG_LEVEL/g" $NODE_CONF_FILE
   sed -i "s/\$NODE_HOST/$NODE_HOST/g" $NODE_CONF_FILE

--- a/falkordb-node/node-entrypoint.sh
+++ b/falkordb-node/node-entrypoint.sh
@@ -439,6 +439,8 @@ get_self_host_ip
 
 if [ "$RUN_NODE" -eq "1" ]; then
 
+  # Update .SO path for old instances
+  sed -i "s|/FalkorDB/bin/src/falkordb.so|/var/lib/falkordb/bin/falkordb.so|g" $NODE_CONF_FILE
   sed -i "s/\$NODE_HOST/$NODE_HOST/g" $NODE_CONF_FILE
   sed -i "s/\$NODE_PORT/$NODE_PORT/g" $NODE_CONF_FILE
   sed -i "s/\$FALKORDB_POST_UPGRADE_PASSWORD/$FALKORDB_POST_UPGRADE_PASSWORD/g" $NODE_CONF_FILE

--- a/healthcheck_rs/src/main.rs
+++ b/healthcheck_rs/src/main.rs
@@ -168,17 +168,8 @@ fn get_health_config_from_configmap() -> Result<HealthConfig, Box<dyn std::error
                     Ok(HealthConfig::default())
                 }
             }
-            Ok(Err(err)) => {
-                eprintln!(
-                    "healthcheck: Failed to get ConfigMap {} in {}: {}",
-                    name, ns, err
-                );
-                Ok(HealthConfig::default())
-            }
-            Err(_) => {
-                eprintln!("healthcheck: ConfigMap fetch timed out; using defaults.");
-                Ok(HealthConfig::default())
-            }
+            Ok(Err(err)) => Ok(HealthConfig::default()),
+            Err(_) => Ok(HealthConfig::default()),
         }
     })?;
 


### PR DESCRIPTION
fix #374 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically updates a legacy library path during node and cluster startup so older installations continue running after upgrades; no change to runtime behavior beyond this compatibility fix.
* **Chores**
  * Simplified health-check config handling to silently fall back to defaults on config retrieval errors, reducing log noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->