### PR TITLE
415 increase sentinel sidecar memory limit

### DIFF
--- a/compose/omnistrate.enterprise.byoa.yaml
+++ b/compose/omnistrate.enterprise.byoa.yaml
@@ -820,6 +820,8 @@ services:
         required: false
         export: false
         defaultValue: "2"
+        min: 2
+        max: 2
         parameterDependencyMap:
           node-sz: numReplicas
       - key: enableTLS
@@ -1569,6 +1571,7 @@ services:
         defaultValue: e2-custom-4-8192
         parameterDependencyMap:
           node-mz: nodeInstanceType
+
       - key: numReplicas
         description: Number of Replicas
         name: Number of Replicas
@@ -1577,6 +1580,8 @@ services:
         required: false
         export: false
         defaultValue: "2"
+        min: 2
+        max: 2
         parameterDependencyMap:
           node-mz: numReplicas
       - key: enableTLS

--- a/compose/omnistrate.enterprise.yaml
+++ b/compose/omnistrate.enterprise.yaml
@@ -823,6 +823,7 @@ services:
         defaultValue: e2-custom-4-8192
         parameterDependencyMap:
           node-sz: nodeInstanceType
+
       - key: numReplicas
         description: Number of Replicas
         name: Number of Replicas
@@ -831,6 +832,8 @@ services:
         required: false
         export: false
         defaultValue: "2"
+        min: 2
+        max: 2
         parameterDependencyMap:
           node-sz: numReplicas
       - key: enableTLS
@@ -1580,6 +1583,7 @@ services:
         defaultValue: e2-custom-4-8192
         parameterDependencyMap:
           node-mz: nodeInstanceType
+
       - key: numReplicas
         description: Number of Replicas
         name: Number of Replicas
@@ -1588,6 +1592,8 @@ services:
         required: false
         export: false
         defaultValue: "2"
+        min: 2
+        max: 2
         parameterDependencyMap:
           node-mz: numReplicas
       - key: enableTLS

--- a/compose/omnistrate.pro.yaml
+++ b/compose/omnistrate.pro.yaml
@@ -854,6 +854,7 @@ services:
           - c6i.8xlarge
         parameterDependencyMap:
           node-sz: nodeInstanceType
+
       - key: numReplicas
         description: Number of Replicas
         name: Number of Replicas
@@ -862,6 +863,8 @@ services:
         required: false
         export: false
         defaultValue: "2"
+        min: 2
+        max: 2
         parameterDependencyMap:
           node-sz: numReplicas
       - key: enableTLS
@@ -1611,6 +1614,7 @@ services:
           - c6i.8xlarge
         parameterDependencyMap:
           node-mz: nodeInstanceType
+
       - key: numReplicas
         description: Number of Replicas
         name: Number of Replicas
@@ -1619,6 +1623,8 @@ services:
         required: false
         export: false
         defaultValue: "2"
+        min: 2
+        max: 2
         parameterDependencyMap:
           node-mz: numReplicas
       - key: enableTLS


### PR DESCRIPTION
fix #415
fix #416  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced a fixed replica count of 2 across Standalone, Single-Zone, Multi-Zone, and Cluster deployments, providing consistent high availability and clearer validation when configuring replicas.
  * Increased memory allocation for monitoring/health sidecars from 50Mi to 100Mi across all deployment modes, improving stability and resilience under load.
  * Changes apply across Pro, Enterprise, and BYOA configurations to ensure consistent behavior and resource defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->