### PR TITLE
bump FalkorDB version to v4.14.3-alpine in workflows and Dockerfiles

### DIFF
--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -19,7 +19,7 @@ env:
   HEALTHCHECK_IMAGE_NAME: falkordb-cloud-healthcheck
   FALKORDB_EXPORTER_IMAGE_NAME: falkordb-cloud-exporter
   FALKORDB_SENTINEL_IMAGE_NAME: falkordb-cloud-sentinel
-  FALKORDB_VERSION: v4.14.0-alpine
+  FALKORDB_VERSION: v4.14.3-alpine
   
 jobs:
   build-and-push:

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -41,7 +41,7 @@ env:
   HEALTHCHECK_IMAGE_NAME: falkordb-cloud-healthcheck
   FALKORDB_EXPORTER_IMAGE_NAME: falkordb-cloud-exporter
   FALKORDB_SENTINEL_IMAGE_NAME: falkordb-cloud-sentinel
-  FALKORDB_VERSION: v4.14.0-alpine
+  FALKORDB_VERSION: v4.14.3-alpine
   FREE_PLAN_NAME: free-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'schedule' || github.ref_name }}
   PRO_PLAN_NAME: pro-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'schedule' || github.ref_name }}
   ENTERPRISE_PLAN_NAME: enterprise-${{ contains(github.ref, 'refs/tags/v') && 'main' || github.event_name == 'pull_request' && github.event.pull_request.head.ref || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'schedule' || github.ref_name }}

--- a/src/falkordb-cluster/Dockerfile
+++ b/src/falkordb-cluster/Dockerfile
@@ -1,4 +1,4 @@
-ARG FALKORDB_VERSION=v4.14.0-alpine
+ARG FALKORDB_VERSION=v4.14.3-alpine
 
 FROM falkordb/falkordb-server:$FALKORDB_VERSION
 

--- a/src/falkordb-node/Dockerfile
+++ b/src/falkordb-node/Dockerfile
@@ -1,4 +1,4 @@
-ARG FALKORDB_VERSION=v4.14.0-alpine
+ARG FALKORDB_VERSION=v4.14.3-alpine
 
 FROM falkordb/falkordb-server:$FALKORDB_VERSION
 

--- a/src/falkordb-sentinel/Dockerfile
+++ b/src/falkordb-sentinel/Dockerfile
@@ -1,4 +1,4 @@
-ARG FALKORDB_VERSION=v4.14.0-alpine
+ARG FALKORDB_VERSION=v4.14.3-alpine
 
 FROM falkordb/falkordb-server:$FALKORDB_VERSION
 


### PR DESCRIPTION
fix #418 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image version to v4.14.3-alpine across all Docker build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->