### PR TITLE
Revert "Addressing PR comments"

### DIFF
--- a/src/falkordb-cluster/cluster-entrypoint.sh
+++ b/src/falkordb-cluster/cluster-entrypoint.sh
@@ -61,14 +61,6 @@ BUS_PORT=${BUS_PORT:-16379}
 
 ROOT_CA_PATH=${ROOT_CA_PATH:-/etc/ssl/certs/ca-certificates.crt}
 TLS_MOUNT_PATH=${TLS_MOUNT_PATH:-/etc/tls}
-SELF_SIGNED_CA_FILE=${SELF_SIGNED_CA_FILE:-$TLS_MOUNT_PATH/selfsigned-ca.crt}
-TLS_CA_CERT_FILE=${TLS_CA_CERT_FILE:-}
-SELF_SIGNED_CERT_FILE=${SELF_SIGNED_CERT_FILE:-$TLS_MOUNT_PATH/selfsigned-tls.crt}
-SELF_SIGNED_KEY_FILE=${SELF_SIGNED_KEY_FILE:-$TLS_MOUNT_PATH/selfsigned-tls.key}
-SERVER_TLS_CERT_FILE=${SERVER_TLS_CERT_FILE:-$TLS_MOUNT_PATH/tls.crt}
-SERVER_TLS_KEY_FILE=${SERVER_TLS_KEY_FILE:-$TLS_MOUNT_PATH/tls.key}
-CLIENT_TLS_CERT_FILE=${CLIENT_TLS_CERT_FILE:-$SERVER_TLS_CERT_FILE}
-CLIENT_TLS_KEY_FILE=${CLIENT_TLS_KEY_FILE:-$SERVER_TLS_KEY_FILE}
 DATA_DIR=${DATA_DIR:-"${FALKORDB_HOME}/data"}
 
 # Add backward compatibility for /data folder
@@ -84,21 +76,6 @@ if [[ $(basename "$DATA_DIR") != 'data' ]];then DATA_DIR=$DATA_DIR/data;fi
 
 DEBUG=${DEBUG:-0}
 REPLACE_NODE_CONF=${REPLACE_NODE_CONF:-0}
-TLS_CA_CERT_FILE=${TLS_CA_CERT_FILE:-$DATA_DIR/selfsigned-tls-combined.pem}
-if [[ "$TLS" == "true" ]]; then
-  BASE_CA_PATH=$ROOT_CA_PATH
-  if [[ -f "$SELF_SIGNED_CA_FILE" && -f "$BASE_CA_PATH" ]]; then
-    if cat "$BASE_CA_PATH" "$SELF_SIGNED_CA_FILE" >"$TLS_CA_CERT_FILE"; then
-      ROOT_CA_PATH=$TLS_CA_CERT_FILE
-    else
-      ROOT_CA_PATH=$BASE_CA_PATH
-    fi
-  elif [[ -f "$TLS_CA_CERT_FILE" ]]; then
-    ROOT_CA_PATH=$TLS_CA_CERT_FILE
-  elif [[ -f "$SELF_SIGNED_CA_FILE" ]]; then
-    ROOT_CA_PATH=$SELF_SIGNED_CA_FILE
-  fi
-fi
 TLS_CONNECTION_STRING=$(if [[ $TLS == "true" ]]; then echo "--tls --cacert $ROOT_CA_PATH"; else echo ""; fi)
 AUTH_CONNECTION_STRING="-a $ADMIN_PASSWORD --no-auth-warning"
 SAVE_LOGS_TO_FILE=${SAVE_LOGS_TO_FILE:-1}
@@ -119,7 +96,7 @@ if [[ ! -s "$FALKORDB_HOME/run_bgrewriteaof" && ! -f "$FALKORDB_HOME/run_bgrewri
       #!/bin/bash
       set -e
       AOF_FILE_SIZE_TO_MONITOR=\${AOF_FILE_SIZE_TO_MONITOR:-5}
-      ROOT_CA_PATH=\${ROOT_CA_PATH:-$TLS_CA_CERT_FILE}
+      ROOT_CA_PATH=\${ROOT_CA_PATH:-/etc/ssl/certs/ca-certificates.crt}
       TLS_CONNECTION_STRING=$(if [[ \$TLS == "true" ]]; then echo "--tls --cacert \$ROOT_CA_PATH"; else echo ""; fi)
       size=\$(stat -c%s $DATA_DIR/appendonlydir/appendonly.aof.*.incr.aof)
       if [ \$size -gt \$((AOF_FILE_SIZE_TO_MONITOR * 1024 * 1024)) ]; then
@@ -565,45 +542,11 @@ run_node() {
     if ! grep -q "^tls-port $NODE_PORT" "$NODE_CONF_FILE"; then
       echo "port 0" >>$NODE_CONF_FILE
       echo "tls-port $NODE_PORT" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-cert-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-cert-file .*|tls-cert-file $SERVER_TLS_CERT_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-cert-file $SERVER_TLS_CERT_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-key-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-key-file .*|tls-key-file $SERVER_TLS_KEY_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-key-file $SERVER_TLS_KEY_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-client-cert-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-client-cert-file .*|tls-client-cert-file $SELF_SIGNED_CERT_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-client-cert-file $SELF_SIGNED_CERT_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-client-key-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-client-key-file .*|tls-client-key-file $SELF_SIGNED_KEY_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-client-key-file $SELF_SIGNED_KEY_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-ca-cert-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-ca-cert-file .*|tls-ca-cert-file $ROOT_CA_PATH|" "$NODE_CONF_FILE"
-    else
+      echo "tls-cert-file $TLS_MOUNT_PATH/tls.crt" >>$NODE_CONF_FILE
+      echo "tls-key-file $TLS_MOUNT_PATH/tls.key" >>$NODE_CONF_FILE
       echo "tls-ca-cert-file $ROOT_CA_PATH" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-cluster " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-cluster .*|tls-cluster yes|" "$NODE_CONF_FILE"
-    else
       echo "tls-cluster yes" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-auth-clients " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-auth-clients .*|tls-auth-clients optional|" "$NODE_CONF_FILE"
-    else
-      echo "tls-auth-clients optional" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-replication " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-replication .*|tls-replication yes|" "$NODE_CONF_FILE"
-    else
+      echo "tls-auth-clients no" >>$NODE_CONF_FILE
       echo "tls-replication yes" >>$NODE_CONF_FILE
     fi
   else
@@ -668,22 +611,7 @@ if [[ "$TLS" == "true" ]]; then
     #!/bin/bash
     set -e
     echo 'Refreshing node certificate'
-    ROOT_CA_PATH=\"$ROOT_CA_PATH\"
-    BASE_CA_PATH=\"$BASE_CA_PATH\"
-    SELF_SIGNED_CA_FILE=\"$SELF_SIGNED_CA_FILE\"
-    TLS_CA_CERT_FILE=\"$TLS_CA_CERT_FILE\"
-    if [[ -f \"$SELF_SIGNED_CA_FILE\" && -f \"$BASE_CA_PATH\" ]]; then
-      cat \"$BASE_CA_PATH\" \"$SELF_SIGNED_CA_FILE\" >\"$TLS_CA_CERT_FILE\"
-      ROOT_CA_PATH=\"$TLS_CA_CERT_FILE\"
-    elif [[ -f \"$TLS_CA_CERT_FILE\" ]]; then
-      ROOT_CA_PATH=\"$TLS_CA_CERT_FILE\"
-    fi
-    TLS_CONNECTION_STRING=\"--tls --cacert \$ROOT_CA_PATH\"
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-cert-file $SERVER_TLS_CERT_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-key-file $SERVER_TLS_KEY_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-client-cert-file $SELF_SIGNED_CERT_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-client-key-file $SELF_SIGNED_KEY_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-ca-cert-file \$ROOT_CA_PATH
+    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning $TLS_CONNECTION_STRING CONFIG SET tls-cert-file $TLS_MOUNT_PATH/tls.crt
     " >$DATA_DIR/cert_rotate_node.sh
     chmod +x $DATA_DIR/cert_rotate_node.sh
   fi

--- a/src/falkordb-node/node-entrypoint.sh
+++ b/src/falkordb-node/node-entrypoint.sh
@@ -71,14 +71,6 @@ FALKORDB_MASTER_PORT_NUMBER=${MASTER_PORT:-6379}
 IS_REPLICA=${IS_REPLICA:-0}
 ROOT_CA_PATH=${ROOT_CA_PATH:-/etc/ssl/certs/ca-certificates.crt}
 TLS_MOUNT_PATH=${TLS_MOUNT_PATH:-/etc/tls}
-SELF_SIGNED_CA_FILE=${SELF_SIGNED_CA_FILE:-$TLS_MOUNT_PATH/selfsigned-ca.crt}
-TLS_CA_CERT_FILE=${TLS_CA_CERT_FILE:-}
-SELF_SIGNED_CERT_FILE=${SELF_SIGNED_CERT_FILE:-$TLS_MOUNT_PATH/selfsigned-tls.crt}
-SELF_SIGNED_KEY_FILE=${SELF_SIGNED_KEY_FILE:-$TLS_MOUNT_PATH/selfsigned-tls.key}
-SERVER_TLS_CERT_FILE=${SERVER_TLS_CERT_FILE:-$TLS_MOUNT_PATH/tls.crt}
-SERVER_TLS_KEY_FILE=${SERVER_TLS_KEY_FILE:-$TLS_MOUNT_PATH/tls.key}
-CLIENT_TLS_CERT_FILE=${CLIENT_TLS_CERT_FILE:-$SERVER_TLS_CERT_FILE}
-CLIENT_TLS_KEY_FILE=${CLIENT_TLS_KEY_FILE:-$SERVER_TLS_KEY_FILE}
 DATA_DIR=${DATA_DIR:-"${FALKORDB_HOME}/data"}
 
 # Add backward compatibility for /data folder
@@ -91,30 +83,13 @@ if [[ "$DATA_DIR" != '/data' ]]; then
 fi
 
 if [[ $(basename "$DATA_DIR") != 'data' ]];then DATA_DIR=$DATA_DIR/data;fi
-TLS_CA_CERT_FILE=${TLS_CA_CERT_FILE:-$DATA_DIR/selfsigned-tls-combined.pem}
 
 DEBUG=${DEBUG:-0}
 REPLACE_NODE_CONF=${REPLACE_NODE_CONF:-0}
+TLS_CONNECTION_STRING=$(if [[ $TLS == "true" ]]; then echo "--tls --cacert $ROOT_CA_PATH"; else echo ""; fi)
 AUTH_CONNECTION_STRING="-a $ADMIN_PASSWORD --no-auth-warning"
 SAVE_LOGS_TO_FILE=${SAVE_LOGS_TO_FILE:-1}
 LOG_LEVEL=${LOG_LEVEL:-notice}
-
-if [[ "$TLS" == "true" ]]; then
-  BASE_CA_PATH=$ROOT_CA_PATH
-  if [[ -f "$SELF_SIGNED_CA_FILE" && -f "$BASE_CA_PATH" ]]; then
-    if cat "$BASE_CA_PATH" "$SELF_SIGNED_CA_FILE" >"$TLS_CA_CERT_FILE"; then
-      ROOT_CA_PATH=$TLS_CA_CERT_FILE
-    else
-      ROOT_CA_PATH=$BASE_CA_PATH
-    fi
-  elif [[ -f "$TLS_CA_CERT_FILE" ]]; then
-    ROOT_CA_PATH=$TLS_CA_CERT_FILE
-  elif [[ -f "$SELF_SIGNED_CA_FILE" ]]; then
-    ROOT_CA_PATH=$SELF_SIGNED_CA_FILE
-  fi
-fi
-
-TLS_CONNECTION_STRING=$(if [[ $TLS == "true" ]]; then echo "--tls --cacert $ROOT_CA_PATH"; else echo ""; fi)
 
 DATE_NOW=$(date +"%Y%m%d%H%M%S")
 
@@ -133,7 +108,7 @@ echo "
     #!/bin/bash
     set -e
     AOF_FILE_SIZE_TO_MONITOR=\${AOF_FILE_SIZE_TO_MONITOR:-5}
-    ROOT_CA_PATH=\${ROOT_CA_PATH:-$TLS_CA_CERT_FILE}
+    ROOT_CA_PATH=\${ROOT_CA_PATH:-/etc/ssl/certs/ca-certificates.crt}
     TLS_CONNECTION_STRING=$(if [[ \$TLS == "true" ]]; then echo "--tls --cacert \$ROOT_CA_PATH"; else echo ""; fi)
     size=0
     for file in $DATA_DIR/appendonlydir/appendonly.aof.*.incr.aof; do
@@ -593,41 +568,11 @@ if [ "$RUN_NODE" -eq "1" ]; then
     if ! grep -q "^tls-port $NODE_PORT" "$NODE_CONF_FILE"; then
       echo "port 0" >>$NODE_CONF_FILE
       echo "tls-port $NODE_PORT" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-cert-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-cert-file .*|tls-cert-file $SERVER_TLS_CERT_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-cert-file $SERVER_TLS_CERT_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-key-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-key-file .*|tls-key-file $SERVER_TLS_KEY_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-key-file $SERVER_TLS_KEY_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-client-cert-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-client-cert-file .*|tls-client-cert-file $SELF_SIGNED_CERT_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-client-cert-file $SELF_SIGNED_CERT_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-client-key-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-client-key-file .*|tls-client-key-file $SELF_SIGNED_KEY_FILE|" "$NODE_CONF_FILE"
-    else
-      echo "tls-client-key-file $SELF_SIGNED_KEY_FILE" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-ca-cert-file " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-ca-cert-file .*|tls-ca-cert-file $ROOT_CA_PATH|" "$NODE_CONF_FILE"
-    else
+      echo "tls-cert-file $TLS_MOUNT_PATH/tls.crt" >>$NODE_CONF_FILE
+      echo "tls-key-file $TLS_MOUNT_PATH/tls.key" >>$NODE_CONF_FILE
       echo "tls-ca-cert-file $ROOT_CA_PATH" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-replication " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-replication .*|tls-replication yes|" "$NODE_CONF_FILE"
-    else
       echo "tls-replication yes" >>$NODE_CONF_FILE
-    fi
-    if grep -q "^tls-auth-clients " "$NODE_CONF_FILE"; then
-      sed -i "s|^tls-auth-clients .*|tls-auth-clients optional|" "$NODE_CONF_FILE"
-    else
-      echo "tls-auth-clients optional" >>$NODE_CONF_FILE
+      echo "tls-auth-clients no" >>$NODE_CONF_FILE
     fi
   else
     if ! grep -q "^port $NODE_PORT" "$NODE_CONF_FILE"; then
@@ -693,22 +638,7 @@ if [[ "$TLS" == "true" ]]; then
     #!/bin/bash
     set -e
     echo 'Refreshing node certificate'
-    ROOT_CA_PATH=\"$ROOT_CA_PATH\"
-    BASE_CA_PATH=\"$BASE_CA_PATH\"
-    SELF_SIGNED_CA_FILE=\"$SELF_SIGNED_CA_FILE\"
-    TLS_CA_CERT_FILE=\"$TLS_CA_CERT_FILE\"
-    if [[ -f \"$SELF_SIGNED_CA_FILE\" && -f \"$BASE_CA_PATH\" ]]; then
-      cat \"$BASE_CA_PATH\" \"$SELF_SIGNED_CA_FILE\" >\"$TLS_CA_CERT_FILE\"
-      ROOT_CA_PATH=\"$TLS_CA_CERT_FILE\"
-    elif [[ -f \"$TLS_CA_CERT_FILE\" ]]; then
-      ROOT_CA_PATH=\"$TLS_CA_CERT_FILE\"
-    fi
-    TLS_CONNECTION_STRING=\"--tls --cacert \$ROOT_CA_PATH\"
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-cert-file $SERVER_TLS_CERT_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-key-file $SERVER_TLS_KEY_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-client-cert-file $SELF_SIGNED_CERT_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-client-key-file $SELF_SIGNED_KEY_FILE
-    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning \$TLS_CONNECTION_STRING CONFIG SET tls-ca-cert-file \$ROOT_CA_PATH
+    redis-cli -p $NODE_PORT -a \$(cat /run/secrets/adminpassword) --no-auth-warning $TLS_CONNECTION_STRING CONFIG SET tls-cert-file $TLS_MOUNT_PATH/tls.crt
     " >$DATA_DIR/cert_rotate_node.sh
     chmod +x $DATA_DIR/cert_rotate_node.sh
   fi

--- a/src/falkordb-sentinel/sentinel-entrypoint.sh
+++ b/src/falkordb-sentinel/sentinel-entrypoint.sh
@@ -37,14 +37,7 @@ SENTINEL_HOST=sentinel-$(echo $RESOURCE_ALIAS | cut -d "-" -f 2)-0.$LOCAL_DNS_SU
 SENTINEL_PORT=${SENTINEL_PORT:-26379}
 ROOT_CA_PATH=${ROOT_CA_PATH:-/etc/ssl/certs/ca-certificates.crt}
 TLS_MOUNT_PATH=${TLS_MOUNT_PATH:-/etc/tls}
-SELF_SIGNED_CA_FILE=${SELF_SIGNED_CA_FILE:-$TLS_MOUNT_PATH/selfsigned-ca.crt}
-TLS_CA_CERT_FILE=${TLS_CA_CERT_FILE:-}
-SELF_SIGNED_CERT_FILE=${SELF_SIGNED_CERT_FILE:-$TLS_MOUNT_PATH/selfsigned-tls.crt}
-SELF_SIGNED_KEY_FILE=${SELF_SIGNED_KEY_FILE:-$TLS_MOUNT_PATH/selfsigned-tls.key}
-SERVER_TLS_CERT_FILE=${SERVER_TLS_CERT_FILE:-$TLS_MOUNT_PATH/tls.crt}
-SERVER_TLS_KEY_FILE=${SERVER_TLS_KEY_FILE:-$TLS_MOUNT_PATH/tls.key}
-CLIENT_TLS_CERT_FILE=${CLIENT_TLS_CERT_FILE:-$SERVER_TLS_CERT_FILE}
-CLIENT_TLS_KEY_FILE=${CLIENT_TLS_KEY_FILE:-$SERVER_TLS_KEY_FILE}
+TLS_CONNECTION_STRING=$(if [[ $TLS == "true" ]]; then echo "--tls --cacert $ROOT_CA_PATH"; else echo ""; fi)
 AUTH_CONNECTION_STRING="-a $ADMIN_PASSWORD --no-auth-warning"
 
 MASTER_NAME=${MASTER_NAME:-master}
@@ -62,22 +55,6 @@ if [[ "$DATA_DIR" != '/data' ]]; then
 fi
 
 if [[ $(basename "$DATA_DIR") != 'data' ]]; then DATA_DIR=$DATA_DIR/data; fi
-TLS_CA_CERT_FILE=${TLS_CA_CERT_FILE:-$DATA_DIR/selfsigned-tls-combined.pem}
-if [[ "$TLS" == "true" ]]; then
-  BASE_CA_PATH=$ROOT_CA_PATH
-  if [[ -f "$SELF_SIGNED_CA_FILE" && -f "$BASE_CA_PATH" ]]; then
-    if cat "$BASE_CA_PATH" "$SELF_SIGNED_CA_FILE" >"$TLS_CA_CERT_FILE"; then
-      ROOT_CA_PATH=$TLS_CA_CERT_FILE
-    else
-      ROOT_CA_PATH=$BASE_CA_PATH
-    fi
-  elif [[ -f "$TLS_CA_CERT_FILE" ]]; then
-    ROOT_CA_PATH=$TLS_CA_CERT_FILE
-  elif [[ -f "$SELF_SIGNED_CA_FILE" ]]; then
-    ROOT_CA_PATH=$SELF_SIGNED_CA_FILE
-  fi
-  TLS_CONNECTION_STRING="--tls --cacert $ROOT_CA_PATH"
-fi
 
 SENTINEL_CONF_FILE=$DATA_DIR/sentinel.conf
 SENTINEL_LOG_FILE_PATH=$(if [[ $SAVE_LOGS_TO_FILE -eq 1 ]]; then echo $DATA_DIR/sentinel_$DATE_NOW.log; else echo ""; fi)
@@ -212,41 +189,11 @@ if [[ "$RUN_SENTINEL" -eq "1" ]] && ([[ "$NODE_INDEX" == "0" || "$NODE_INDEX" ==
     if ! grep -q "^tls-port $SENTINEL_PORT" "$SENTINEL_CONF_FILE"; then
       echo "port 0" >>$SENTINEL_CONF_FILE
       echo "tls-port $SENTINEL_PORT" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-cert-file " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-cert-file .*|tls-cert-file $SERVER_TLS_CERT_FILE|" "$SENTINEL_CONF_FILE"
-    else
-      echo "tls-cert-file $SERVER_TLS_CERT_FILE" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-key-file " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-key-file .*|tls-key-file $SERVER_TLS_KEY_FILE|" "$SENTINEL_CONF_FILE"
-    else
-      echo "tls-key-file $SERVER_TLS_KEY_FILE" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-client-cert-file " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-client-cert-file .*|tls-client-cert-file $SELF_SIGNED_CERT_FILE|" "$SENTINEL_CONF_FILE"
-    else
-      echo "tls-client-cert-file $SELF_SIGNED_CERT_FILE" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-client-key-file " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-client-key-file .*|tls-client-key-file $SELF_SIGNED_KEY_FILE|" "$SENTINEL_CONF_FILE"
-    else
-      echo "tls-client-key-file $SELF_SIGNED_KEY_FILE" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-ca-cert-file " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-ca-cert-file .*|tls-ca-cert-file $ROOT_CA_PATH|" "$SENTINEL_CONF_FILE"
-    else
+      echo "tls-cert-file $TLS_MOUNT_PATH/tls.crt" >>$SENTINEL_CONF_FILE
+      echo "tls-key-file $TLS_MOUNT_PATH/tls.key" >>$SENTINEL_CONF_FILE
       echo "tls-ca-cert-file $ROOT_CA_PATH" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-replication " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-replication .*|tls-replication yes|" "$SENTINEL_CONF_FILE"
-    else
       echo "tls-replication yes" >>$SENTINEL_CONF_FILE
-    fi
-    if grep -q "^tls-auth-clients " "$SENTINEL_CONF_FILE"; then
-      sed -i "s|^tls-auth-clients .*|tls-auth-clients optional|" "$SENTINEL_CONF_FILE"
-    else
-      echo "tls-auth-clients optional" >>$SENTINEL_CONF_FILE
+      echo "tls-auth-clients no" >>$SENTINEL_CONF_FILE
     fi
   else
     echo "port $SENTINEL_PORT" >>$SENTINEL_CONF_FILE


### PR DESCRIPTION
Reverts FalkorDB/falkordb-omnistrate#578

the selfsigned CA upgrade will be a bit more complicated than i thought. The rolling upgrade leaves the cluster stuck after 1 shard is upgraded, since that shard will try to connect to the other nodes using the selfsigned cert, which is not known to them before the upgrade.
it means we'll have to upgrade in 2 phases:
a. After omnistrate rolls out the selfsigned cert for all clusters, we'll have the first version upgrade which only expands the CA file to include the selfsigned CA too.
b. Then, the second version will effectively change the certs, and during the upgrade the selfsigned CA will already be trusted, so no problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined TLS/SSL certificate configuration across cluster, node, and sentinel components by consolidating environment variables and using centralized certificate paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->