### PR TITLE
refactor: remove e2-medium instances from service options before release

### DIFF
--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -182,8 +182,8 @@ jobs:
         if: ${{ contains( vars.OMNISTRATE_RELEASE_PLANS, matrix.plans.key) && (matrix.plans.key == 'pro' || matrix.plans.key == 'enterprise') }}
         working-directory: compose
         run: |
-          sed -i 's/- e2-medium//g' ${{ matrix.plans.file }}
-          sed -i 's/- t2.medium//g' ${{ matrix.plans.file }}
+          sed -i 's/- "e2-medium"//g' ${{ matrix.plans.file }}
+          sed -i 's/- "t2.medium"//g' ${{ matrix.plans.file }}
 
       - name: Enable snapshotBeforeDeletion
         if: ${{ contains( vars.OMNISTRATE_RELEASE_PLANS, matrix.plans.key) && (matrix.plans.key != 'free')}}


### PR DESCRIPTION
fix #593 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the build workflow configuration where certain machine types were not being properly removed from plan definitions due to quote matching patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->