### PR TITLE
fix: handle missing ConfigMap gracefully in health check

### DIFF
--- a/src/healthcheck_rs/src/main.rs
+++ b/src/healthcheck_rs/src/main.rs
@@ -365,6 +365,10 @@ fn get_health_config_from_configmap() -> Result<HealthConfig, Box<dyn std::error
                     Ok(HealthConfig::default())
                 }
             }
+            Ok(Err(kube::Error::Api(ref err))) if err.code == 404 => {
+                // ConfigMap is optional — not found is expected when it hasn't been created.
+                Ok(HealthConfig::default())
+            }
             Ok(Err(e)) => {
                 eprintln!("healthcheck: Kubernetes API error fetching ConfigMap \"{}\": {}; using defaults.", name, e);
                 Ok(HealthConfig::default())


### PR DESCRIPTION
fix #623 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved healthcheck handling of missing configurations. Missing Kubernetes ConfigMaps now return default settings gracefully without error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->