### PR TITLE
Fix image tag format in Grype scan step of build-release workflow

### DIFF
--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v6
         id: grype
         with:
-          image: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}-${{ matrix.platform }}
+          image: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}
           fail-build: true
           severity-cutoff: high
           output-format: sarif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning configuration in the build workflow to scan image tags without platform-specific suffixes, ensuring consistent scan identification across build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->