### PR TITLE
Add Docker credentials to Grype scan step in build-release workflow

### DIFF
--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -89,17 +89,13 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image.image_name }}-${{ matrix.platform }}
           tags: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}, falkordb/${{ matrix.image.image_name }}:latest-${{ matrix.platform }}
 
-      - name: Login to Docker Hub for Grype scan
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKER_PULL_USERNAME }}
-          password: ${{ secrets.DOCKER_PULL_PASSWORD }}
-
       - name: Scan image with Grype
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v6
         id: grype
         with:
           image: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}
+          registry-username: ${{ secrets.DOCKER_USERNAME }}
+          registry-password: ${{ secrets.DOCKER_PASSWORD }}
           fail-build: true
           severity-cutoff: high
           output-format: sarif

--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -89,12 +89,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image.image_name }}-${{ matrix.platform }}
           tags: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}, falkordb/${{ matrix.image.image_name }}:latest-${{ matrix.platform }}
 
+      - name: Login to Docker Hub for Grype scan
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_PULL_USERNAME }}
+          password: ${{ secrets.DOCKER_PULL_PASSWORD }}
+
       - name: Scan image with Grype
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v6
         id: grype
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_PULL_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PULL_PASSWORD }}
         with:
           image: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}
           fail-build: true

--- a/.github/workflows/build-release-image.yaml
+++ b/.github/workflows/build-release-image.yaml
@@ -92,6 +92,9 @@ jobs:
       - name: Scan image with Grype
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v6
         id: grype
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_PULL_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PULL_PASSWORD }}
         with:
           image: falkordb/${{ matrix.image.image_name }}:${{ steps.set_tag.outputs.tag }}
           fail-build: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline authentication for improved security scanning reliability during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->