### PR TITLE
Update Redis exporter version to v1.71.2

### DIFF
--- a/src/falkordb-exporter/Dockerfile
+++ b/src/falkordb-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM falkordb/redis_exporter:v1.71.1-alpine AS redis_exporter
+FROM falkordb/redis_exporter:v1.71.2-alpine AS redis_exporter
 
 FROM alpine:latest
 


### PR DESCRIPTION
fix #651 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated redis exporter to version v1.71.2-alpine, including the latest patch improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->